### PR TITLE
Fix for bug #1

### DIFF
--- a/src/HBaseClient.java
+++ b/src/HBaseClient.java
@@ -1473,6 +1473,7 @@ public final class HBaseClient {
     final class RetryRpc implements Callback<Deferred<Object>, Object> {
       public Deferred<Object> call(final Object arg) {
         if (arg instanceof NonRecoverableException) {
+          request.callback(arg);
           return Deferred.fromError((NonRecoverableException) arg);
         }
         return sendRpcToRegion(request);


### PR DESCRIPTION
If a .META. or -ROOT- lookup for a probe request leads to a
NonRecoverableException (eg. when the region server serving either
is down, leading to an underlying RegionServerStoppedException), the
probe's callback (RetryRPC) is not executed. Now, if an upstream
request comes in and sets the meta cache to a stale entry, all further
requests will go to the wrong the regionserver and NSRE. The cache entry
for the region is never deleted as that is the responsibility of the probe,
which is now "lost"! The bug manifests itself at the client in various
ways, like the client hanging up on regionserver restarts or continuos
PleaseThrottleExceptions even after the Region is back online. This
patch fixes the issue by triggering the callback when there is a
NonRecoverableException for a request.
