### PR TITLE
Introduce HBASE append support and force HBaceClient to search region in meta table instead of getting from cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,7 @@ PROTOBUF_GEN_DIR = $(top_builddir)/src/org/hbase/async/generated
 BUILT_SOURCES := $(asynchbase_PROTOS:protobuf/%.proto=$(PROTOBUF_GEN_DIR)/%PB.java)
 
 asynchbase_SOURCES := \
+	src/AppendRequest.java	\
 	src/AtomicIncrementRequest.java	\
 	src/BatchableRpc.java	\
 	src/BrokenMetaException.java	\

--- a/src/AppendRequest.java
+++ b/src/AppendRequest.java
@@ -1,0 +1,616 @@
+/*
+ * Copyright (C) 2010-2012  The Async HBase Authors.  All rights reserved.
+ * This file is part of Async HBase.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   - Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *   - Neither the name of the StumbleUpon nor the names of its contributors
+ *     may be used to endorse or promote products derived from this software
+ *     without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hbase.async;
+
+import org.hbase.async.generated.ClientPB;
+import org.jboss.netty.buffer.ChannelBuffer;
+
+/**
+ * Appends some data into HBase.
+ *
+ * <h1>A note on passing {@code byte} arrays in argument</h1>
+ * None of the method that receive a {@code byte[]} in argument will copy it.
+ * For more info, please refer to the documentation of {@link HBaseRpc}.
+ * <h1>A note on passing {@code String}s in argument</h1>
+ * All strings are assumed to use the platform's default charset.
+ * <h1>A note on passing {@code timestamp}s in argument</h1>
+ * HBase orders all the writes based on timestamps from {@code AppendRequest}
+ * irrespective of the actual order in which they're received or stored by
+ * a RegionServer.  In other words, if you send a first {@code AppendRequest}
+ * with timestamp T, and then later send another one for the same table,
+ * key, family and qualifier, but with timestamp T - 1, then the second
+ * write will look like it was applied before the first one when you read
+ * this cell back from HBase.  When manually setting timestamps, it is thus
+ * strongly recommended to use real UNIX timestamps in milliseconds, e.g.
+ * from {@link System#currentTimeMillis}.
+ * <p>
+ * If you want to let HBase set the timestamp on a write at the time it's
+ * applied within the RegionServer, then use {@link KeyValue#TIMESTAMP_NOW}
+ * as a timestamp.  The timestamp is set right before being written to the WAL
+ * (Write Ahead Log).  Note however that this has a subtle consequence: if a
+ * write succeeds from the server's point of view, but fails from the client's
+ * point of view (maybe because the client got disconnected from the server
+ * before the server could acknowledge the write), then if the client retries
+ * the write it will create another version of the cell with a different
+ * timestamp.
+ */
+public final class AppendRequest extends HBaseRpc
+  implements HBaseRpc.HasTable, HBaseRpc.HasKey, HBaseRpc.HasFamily,
+             HBaseRpc.HasQualifiers, HBaseRpc.HasValues, HBaseRpc.IsEdit,
+             /* legacy: */ HBaseRpc.HasQualifier, HBaseRpc.HasValue {
+
+  private static final byte[] APPEND = new byte[] { 'a', 'p', 'p', 'e', 'n', 'd' };
+  private static final byte[] RETURN_RESULTS = new byte[] {'_', 'r', 'r', '_'};
+  
+  /** Code type used for serialized `Append' objects.  */
+  static final byte CODE = 78;
+
+
+  /**
+   * Invariants:
+   *   - qualifiers.length == values.length
+   *   - qualifiers.length > 0
+   */
+  private byte[] family;
+  private final byte[][] qualifiers;
+  private final byte[][] values;
+  private boolean returnResult = false;
+  /** The timestamp to use for {@link KeyValue}s of this RPC.  */
+  /*protected*/ final long timestamp;
+
+  /**
+   * Explicit row lock to use, if any.
+   * @see RowLock
+   */
+  /*protected*/ final long lockid;
+  /**
+   * Whether or not the RegionServer must write to its WAL (Write Ahead Log).
+   */
+  /*protected*/ boolean durable = true;
+
+  /**
+   * Constructor using current time.
+   * <strong>These byte arrays will NOT be copied.</strong>
+   * <p>
+   * Note: If you want to set your own timestamp, use
+   * {@link #AppendRequest(byte[], byte[], byte[], byte[], byte[], long)}
+   * instead.  This constructor will let the RegionServer assign the timestamp
+   * to this write at the time using {@link System#currentTimeMillis} right
+   * before the write is persisted to the WAL.
+   * @param table The table to edit.
+   * @param key The key of the row to edit in that table.
+   * @param family The column family to edit in that table.
+   * @param qualifier The column qualifier to edit in that family.
+   * @param value The value to store.
+   */
+  public AppendRequest(final byte[] table,
+                    final byte[] key,
+                    final byte[] family,
+                    final byte[] qualifier,
+                    final byte[] value) {
+    this(table, key, family, qualifier, value,
+         KeyValue.TIMESTAMP_NOW, RowLock.NO_LOCK);
+  }
+
+  /**
+   * Constructor for multiple columns using current time.
+   * <strong>These byte arrays will NOT be copied.</strong>
+   * <p>
+   * Note: If you want to set your own timestamp, use
+   * {@link #AppendRequest(byte[], byte[], byte[], byte[][], byte[][], long)}
+   * instead.  This constructor will let the RegionServer assign the timestamp
+   * to this write at the time using {@link System#currentTimeMillis} right
+   * before the write is persisted to the WAL.
+   * @param table The table to edit.
+   * @param key The key of the row to edit in that table.
+   * @param family The column family to edit in that table.
+   * @param qualifiers The column qualifiers to edit in that family.
+   * @param values The corresponding values to store.
+   * @throws IllegalArgumentException if {@code qualifiers.length == 0}
+   * or if {@code qualifiers.length != values.length}
+   * @since 1.3
+   */
+  public AppendRequest(final byte[] table,
+                    final byte[] key,
+                    final byte[] family,
+                    final byte[][] qualifiers,
+                    final byte[][] values) {
+    this(table, key, family, qualifiers, values,
+         KeyValue.TIMESTAMP_NOW, RowLock.NO_LOCK);
+  }
+
+  /**
+   * Constructor for a specific timestamp.
+   * <strong>These byte arrays will NOT be copied.</strong>
+   * @param table The table to edit.
+   * @param key The key of the row to edit in that table.
+   * @param family The column family to edit in that table.
+   * @param qualifier The column qualifier to edit in that family.
+   * @param value The value to store.
+   * @param timestamp The timestamp to set on this edit.
+   * @since 1.2
+   */
+  public AppendRequest(final byte[] table,
+                    final byte[] key,
+                    final byte[] family,
+                    final byte[] qualifier,
+                    final byte[] value,
+                    final long timestamp) {
+    this(table, key, family, qualifier, value, timestamp, RowLock.NO_LOCK);
+  }
+
+  /**
+   * Constructor for multiple columns with a specific timestamp.
+   * <strong>These byte arrays will NOT be copied.</strong>
+   * @param table The table to edit.
+   * @param key The key of the row to edit in that table.
+   * @param family The column family to edit in that table.
+   * @param qualifiers The column qualifiers to edit in that family.
+   * @param values The corresponding values to store.
+   * @param timestamp The timestamp to set on this edit.
+   * @throws IllegalArgumentException if {@code qualifiers.length == 0}
+   * or if {@code qualifiers.length != values.length}
+   * @since 1.3
+   */
+  public AppendRequest(final byte[] table,
+                    final byte[] key,
+                    final byte[] family,
+                    final byte[][] qualifiers,
+                    final byte[][] values,
+                    final long timestamp) {
+    this(table, key, family, qualifiers, values, timestamp, RowLock.NO_LOCK);
+  }
+
+  /**
+   * Constructor using an explicit row lock.
+   * <strong>These byte arrays will NOT be copied.</strong>
+   * <p>
+   * Note: If you want to set your own timestamp, use
+   * {@link #AppendRequest(byte[], byte[], byte[], byte[], byte[], long, RowLock)}
+   * instead.  This constructor will let the RegionServer assign the timestamp
+   * to this write at the time using {@link System#currentTimeMillis} right
+   * before the write is persisted to the WAL.
+   * @param table The table to edit.
+   * @param key The key of the row to edit in that table.
+   * @param family The column family to edit in that table.
+   * @param qualifier The column qualifier to edit in that family.
+   * @param value The value to store.
+   * @param lock An explicit row lock to use with this request.
+   */
+  public AppendRequest(final byte[] table,
+                    final byte[] key,
+                    final byte[] family,
+                    final byte[] qualifier,
+                    final byte[] value,
+                    final RowLock lock) {
+    this(table, key, family, qualifier, value,
+         KeyValue.TIMESTAMP_NOW, lock.id());
+  }
+
+  /**
+   * Constructor using current time and an explicit row lock.
+   * <strong>These byte arrays will NOT be copied.</strong>
+   * @param table The table to edit.
+   * @param key The key of the row to edit in that table.
+   * @param family The column family to edit in that table.
+   * @param qualifier The column qualifier to edit in that family.
+   * @param value The value to store.
+   * @param timestamp The timestamp to set on this edit.
+   * @param lock An explicit row lock to use with this request.
+   * @since 1.2
+   */
+  public AppendRequest(final byte[] table,
+                    final byte[] key,
+                    final byte[] family,
+                    final byte[] qualifier,
+                    final byte[] value,
+                    final long timestamp,
+                    final RowLock lock) {
+    this(table, key, family, qualifier, value, timestamp, lock.id());
+  }
+
+  /**
+   * Constructor for multiple columns with current time and explicit row lock.
+   * <strong>These byte arrays will NOT be copied.</strong>
+   * @param table The table to edit.
+   * @param key The key of the row to edit in that table.
+   * @param family The column family to edit in that table.
+   * @param qualifiers The column qualifiers to edit in that family.
+   * @param values The corresponding values to store.
+   * @param timestamp The timestamp to set on this edit.
+   * @param lock An explicit row lock to use with this request.
+   * @throws IllegalArgumentException if {@code qualifiers.length == 0}
+   * or if {@code qualifiers.length != values.length}
+   * @since 1.3
+   */
+  public AppendRequest(final byte[] table,
+                    final byte[] key,
+                    final byte[] family,
+                    final byte[][] qualifiers,
+                    final byte[][] values,
+                    final long timestamp,
+                    final RowLock lock) {
+    this(table, key, family, qualifiers, values, timestamp, lock.id());
+  }
+
+  /**
+   * Convenience constructor from strings (higher overhead).
+   * <p>
+   * Note: If you want to set your own timestamp, use
+   * {@link #AppendRequest(byte[], byte[], byte[], byte[], byte[], long)}
+   * instead.  This constructor will let the RegionServer assign the timestamp
+   * to this write at the time using {@link System#currentTimeMillis} right
+   * before the write is persisted to the WAL.
+   * @param table The table to edit.
+   * @param key The key of the row to edit in that table.
+   * @param family The column family to edit in that table.
+   * @param qualifier The column qualifier to edit in that family.
+   * @param value The value to store.
+   */
+  public AppendRequest(final String table,
+                    final String key,
+                    final String family,
+                    final String qualifier,
+                    final String value) {
+    this(table.getBytes(), key.getBytes(), family.getBytes(),
+         qualifier.getBytes(), value.getBytes(),
+         KeyValue.TIMESTAMP_NOW, RowLock.NO_LOCK);
+  }
+
+  /**
+   * Convenience constructor with explicit row lock (higher overhead).
+   * <p>
+   * Note: If you want to set your own timestamp, use
+   * {@link #AppendRequest(byte[], byte[], byte[], byte[], byte[], long, RowLock)}
+   * instead.  This constructor will let the RegionServer assign the timestamp
+   * to this write at the time using {@link System#currentTimeMillis} right
+   * before the write is persisted to the WAL.
+   * @param table The table to edit.
+   * @param key The key of the row to edit in that table.
+   * @param family The column family to edit in that table.
+   * @param qualifier The column qualifier to edit in that family.
+   * @param value The value to store.
+   * @param lock An explicit row lock to use with this request.
+   */
+  public AppendRequest(final String table,
+                    final String key,
+                    final String family,
+                    final String qualifier,
+                    final String value,
+                    final RowLock lock) {
+    this(table.getBytes(), key.getBytes(), family.getBytes(),
+         qualifier.getBytes(), value.getBytes(),
+         KeyValue.TIMESTAMP_NOW, lock.id());
+  }
+
+  /**
+   * Constructor from a {@link KeyValue}.
+   * @param table The table to edit.
+   * @param kv The {@link KeyValue} to store.
+   * @since 1.1
+   */
+  public AppendRequest(final byte[] table,
+                    final KeyValue kv) {
+    this(table, kv, RowLock.NO_LOCK);
+  }
+
+  /**
+   * Constructor from a {@link KeyValue} with an explicit row lock.
+   * @param table The table to edit.
+   * @param kv The {@link KeyValue} to store.
+   * @param lock An explicit row lock to use with this request.
+   * @since 1.1
+   */
+  public AppendRequest(final byte[] table,
+                    final KeyValue kv,
+                    final RowLock lock) {
+    this(table, kv, lock.id());
+  }
+
+  /** Private constructor.  */
+  private AppendRequest(final byte[] table,
+                     final KeyValue kv,
+                     final long lockid) {
+    super(table, kv.key());
+    this.lockid = lockid;
+    this.timestamp = kv.timestamp();
+    this.family = kv.family();
+    this.qualifiers = new byte[][] { kv.qualifier() };
+    this.values = new byte[][] { kv.value() };
+  }
+
+  /** Private constructor.  */
+  private AppendRequest(final byte[] table,
+                     final byte[] key,
+                     final byte[] family,
+                     final byte[] qualifier,
+                     final byte[] value,
+                     final long timestamp,
+                     final long lockid) {
+    this(table, key, family, new byte[][] { qualifier }, new byte[][] { value },
+         timestamp, lockid);
+  }
+
+  /** Private constructor.  */
+  private AppendRequest(final byte[] table,
+                     final byte[] key,
+                     final byte[] family,
+                     final byte[][] qualifiers,
+                     final byte[][] values,
+                     final long timestamp,
+                     final long lockid) {
+      this(table, key, family, qualifiers, values,
+         timestamp, lockid, false);
+  }
+  
+  /** Private constructor.  */
+  private AppendRequest(final byte[] table,
+                     final byte[] key,
+                     final byte[] family,
+                     final byte[][] qualifiers,
+                     final byte[][] values,
+                     final long timestamp,
+                     final long lockid,
+                     final boolean returnResult) {
+    super(table, key);
+    this.timestamp = timestamp;
+    this.lockid = lockid;
+    this.family = family;
+    KeyValue.checkFamily(family);
+    
+    if (qualifiers.length != values.length) {
+      throw new IllegalArgumentException("Have " + qualifiers.length
+        + " qualifiers and " + values.length + " values.  Should be equal.");
+    } else if (qualifiers.length == 0) {
+      throw new IllegalArgumentException("Need at least one qualifier/value.");
+    }
+    for (int i = 0; i < qualifiers.length; i++) {
+      KeyValue.checkQualifier(qualifiers[i]);
+      KeyValue.checkValue(values[i]);
+    }
+    this.qualifiers = qualifiers;
+    this.values = values;
+    this.returnResult = returnResult;
+  }
+
+  @Override
+  public byte[] table() {
+    return table;
+  }
+
+  @Override
+  public byte[] key() {
+    return key;
+  }
+
+  /**
+   * Returns the first qualifier of the set of edits in this RPC.
+   * {@inheritDoc}
+   */
+  @Override
+  public byte[] qualifier() {
+    return qualifiers[0];
+  }
+
+  /**
+   * {@inheritDoc}
+   * @since 1.3
+   */
+  @Override
+  public byte[][] qualifiers() {
+    return qualifiers;
+  }
+
+  /**
+   * Returns the first value of the set of edits in this RPC.
+   * {@inheritDoc}
+   */
+  @Override
+  public byte[] value() {
+    return values[0];
+  }
+
+  /**
+   * {@inheritDoc}
+   * @since 1.3
+   */
+  @Override
+  public byte[][] values() {
+    return values;
+  }
+
+  public void setReturnResult(boolean returnResult) {
+    this.returnResult = returnResult;
+  }
+
+  public String toString() {
+    return super.toStringWithQualifiers("AppendRequest",
+                                       family, qualifiers, values,
+                                       ", timestamp=" + timestamp
+                                       + ", lockid=" + lockid
+                                       + ", durable=" + durable);
+//                                       + ", bufferable=" + super.bufferable);
+  }
+
+  // ---------------------- //
+  // Package private stuff. //
+  // ---------------------- //
+
+//  @Override
+  byte version(final byte server_version) {
+    // Versions are:
+      return 1;
+  }
+
+//  @Override
+  byte code() {
+    return CODE;
+  }
+
+//  @Override
+  int numKeyValues() {
+    return qualifiers.length;
+  }
+
+//  @Override
+  int payloadSize() {
+    int size = 0;
+    for (int i = 0; i < qualifiers.length; i++) {
+      size += KeyValue.predictSerializedSize(key, family, qualifiers[i], values[i]);
+    }
+    return size;
+  }
+
+//  @Override
+  void serializePayload(final ChannelBuffer buf) {
+    for (int i = 0; i < qualifiers.length; i++) {
+    //HBASE KeyValue (org.apache.hadoop.hbase.KeyValue) doesn't have an Append Type
+      KeyValue.serialize(buf, KeyValue.PUT, timestamp, key, family,
+                         qualifiers[i], values[i]);
+    }
+  }
+
+  /**
+   * Predicts a lower bound on the serialized size of this RPC.
+   * This is to avoid using a dynamic buffer, to avoid re-sizing the buffer.
+   * Since we use a static buffer, if the prediction is wrong and turns out
+   * to be less than what we need, there will be an exception which will
+   * prevent the RPC from being serialized.  That'd be a severe bug.
+   */
+  private int predictSerializedSize() {
+    int size = 0;
+    size += 4;  // int:  Number of parameters.
+    size += 1;  // byte: Type of the 1st parameter.
+    size += 3;  // vint: region name length (3 bytes => max length = 32768).
+    size += region.name().length;  // The region name.
+
+    size += predictAppendSize();
+    size += 4;  // int: Number of attributes
+    size += 4;  // int: length of the attribute name
+    size += 4;  // char[]: attribute name
+    size += 1;  // vint: attribute length
+    size += 1;  // vint: attribute value
+    return size;
+  }
+
+  /** The raw size of the underlying `Append'.  */
+  int predictAppendSize() {
+    int size = 0;
+    size += 1;  // byte: Type of the 2nd parameter.
+    size += 1;  // byte: Type again (see HBASE-2877).
+
+    size += 1;  // byte: Version of Append.
+    size += 3;  // vint: row key length (3 bytes => max length = 32768).
+    size += key.length;  // The row key.
+    size += 8;  // long: Timestamp.
+    size += 8;  // long: Lock ID.
+    size += 1;  // bool: Whether or not to write to the WAL.
+    size += 4;  // int:  Number of families for which we have edits.
+
+    size += 1;  // vint: Family length (guaranteed on 1 byte).
+    size += family.length;  // The family.
+    size += 4;  // int:  Number of KeyValues that follow.
+    size += 4;  // int:  Total number of bytes for all those KeyValues.
+
+    size += payloadSize();
+
+    return size;
+  }
+
+  /** Serializes this request.  */
+  @Override
+  ChannelBuffer serialize(final byte server_version) {
+    final ChannelBuffer buf = newBuffer(server_version,
+                                        predictSerializedSize());
+    buf.writeInt(2);  // Number of parameters.
+
+    // 1st param: byte array containing region name
+    writeHBaseByteArray(buf, region.name());
+
+    // 2nd param: Append object
+    serializeInto(buf);
+
+    return buf;
+  }
+
+  /** Serialize the raw underlying `Append' into the given buffer.  */
+  void serializeInto(final ChannelBuffer buf) {
+    buf.writeByte(CODE); // Code for a `Append' parameter.
+    buf.writeByte(CODE); // Code again (see HBASE-2877).
+    buf.writeByte(1);    // Append#APPENDT_VERSION.  Stick to v1 here for now.
+    writeByteArray(buf, key);  // The row key.
+
+    buf.writeLong(timestamp);  // Timestamp.
+
+    buf.writeLong(lockid);    // Lock ID.
+    buf.writeByte(durable ? 0x01 : 0x00);  // Whether or not to use the WAL.
+
+    buf.writeInt(1);  // Number of families that follow.
+    writeByteArray(buf, family);  // The column family.
+
+    buf.writeInt(qualifiers.length);  // Number of "KeyValues" that follow.
+    buf.writeInt(payloadSize());  // Size of the KV that follows.
+    serializePayload(buf);
+    buf.writeInt(1);    // Set one attribute
+    buf.writeInt(4);    // Set attribute name length
+    buf.writeBytes(RETURN_RESULTS);
+    buf.writeByte(1);
+    buf.writeByte(this.returnResult ? 1:0);
+  }
+
+    @Override
+    public byte[] family() {
+        return this.family;
+    }
+
+    public void setDurable(boolean durable) {
+        this.durable = durable;
+    }
+
+    public boolean isDurable() {
+        return durable;
+    }
+
+    @Override
+    Object deserialize(ChannelBuffer buf, int cell_size) {
+        HBaseRpc.ensureNoCell(cell_size);
+        final ClientPB.MutateResponse resp = readProtobuf(buf, 
+            ClientPB.MutateResponse.PARSER);
+        return null;
+    }
+
+    @Override
+    byte[] method(byte server_version) {
+        //TODO. need to see how toMutationProto is overriden for PUT
+//        if (server_version >= RegionClient.SERVER_VERSION_095_OR_ABOVE) {
+//          return MUTATE;
+//        }
+
+        return APPEND;
+    }
+
+}

--- a/src/ClientStats.java
+++ b/src/ClientStats.java
@@ -52,6 +52,7 @@ public final class ClientStats {
   private final long num_scanners_opened;
   private final long num_scans;
   private final long num_puts;
+  private final long num_appends;
   private final long num_row_locks;
   private final long num_deletes;
   private final long num_atomic_increments;
@@ -70,6 +71,7 @@ public final class ClientStats {
               final long num_scanners_opened,
               final long num_scans,
               final long num_puts,
+              final long num_appends,
               final long num_row_locks,
               final long num_deletes,
               final long num_atomic_increments,
@@ -87,6 +89,7 @@ public final class ClientStats {
     this.num_scanners_opened = num_scanners_opened;
     this.num_scans = num_scans;
     this.num_puts = num_puts;
+    this.num_appends = num_appends;
     this.num_row_locks = num_row_locks;
     this.num_deletes = num_deletes;
     this.num_atomic_increments = num_atomic_increments;
@@ -231,6 +234,17 @@ public final class ClientStats {
    */
   public long puts() {
     return num_puts;
+  }
+
+  /**
+   * Number calls to {@link HBaseClient#append}.
+   * <p>
+   * Note that this doesn't necessarily reflect the number of RPCs sent to
+   * HBase due to batching (see {@link HBaseClient#setFlushInterval}).
+   * @see #numBatchedRpcSent
+   */
+  public long appends() {
+    return num_appends;
   }
 
   /** Number calls to {@link HBaseClient#lockRow}.  */

--- a/src/HBaseClient.java
+++ b/src/HBaseClient.java
@@ -223,6 +223,8 @@ public final class HBaseClient {
   private static final RegionInfo META_REGION =
     new RegionInfo(HBASE96_META, META_REGION_NAME, EMPTY_ARRAY);
 
+  public static final int MAX_RETRY_ATTEMPT = 10;
+
   /**
    * In HBase 0.95 and up, this magic number is found in a couple places.
    * It's used in the znode that points to the .META. region, to
@@ -435,6 +437,9 @@ public final class HBaseClient {
   /** Number calls to {@link #put}.  */
   private final Counter num_puts = new Counter();
 
+  /** Number calls to {@link #put}.  */
+  private final Counter num_appends = new Counter();
+
   /** Number calls to {@link #lockRow}.  */
   private final Counter num_row_locks = new Counter();
 
@@ -549,6 +554,7 @@ public final class HBaseClient {
       num_scanners_opened.get(),
       num_scans.get(),
       num_puts.get(),
+      num_appends.get(),
       num_row_locks.get(),
       num_deletes.get(),
       num_atomic_increments.get(),
@@ -1343,6 +1349,25 @@ public final class HBaseClient {
     return sendRpcToRegion(request);
   }
 
+
+  /**
+   * Stores data in HBase.
+   * <p>
+   * Note that this provides no guarantee as to the order in which subsequent
+   * {@code append} requests are going to be applied to the backend.  If you need
+   * ordering, you must enforce it manually yourself by starting the next
+   * {@code append} once the {@link Deferred} of this one completes successfully.
+   * @param request The {@code append} request.
+   * @return A deferred object that indicates the completion of the request.
+   * The {@link Object} has not special meaning and can be {@code null}
+   * (think of it as {@code Deferred<Void>}).  But you probably want to attach
+   * at least an errback to this {@code Deferred} to handle failures.
+   */
+  public Deferred<Object> append(final AppendRequest request) {
+    num_appends.increment();
+    return sendRpcToRegion(request);
+  }
+
   /**
    * Atomic Compare-And-Set (CAS) on a single cell.
    * <p>
@@ -1780,7 +1805,7 @@ public final class HBaseClient {
    * already.
    */
   static boolean cannotRetryRequest(final HBaseRpc rpc) {
-    return rpc.attempt > 10;  // XXX Don't hardcode.
+    return rpc.attempt > MAX_RETRY_ATTEMPT;  // XXX Don't hardcode.
   }
 
   /**

--- a/src/HBaseRpc.java
+++ b/src/HBaseRpc.java
@@ -427,6 +427,19 @@ public abstract class HBaseRpc {
   }
 
   /**
+   * Set to true for probes use to rediscover regions
+   */
+  boolean probe = false;
+
+  public boolean isProbe() {
+    return probe;
+  }
+
+  public void setProbe(boolean probe) {
+    this.probe = probe;
+  }
+
+  /**
    * Package private constructor for RPCs that aren't for any region.
    */
   HBaseRpc() {


### PR DESCRIPTION
There is an open issue, https://github.com/OpenTSDB/asynchbase/issues/65, which causes the hbase client get stuck during region splits. Somehow hbase send wrong region name or client reads wrong region name. Once it happens during heavy writes, it will not be give up or get the right region instead of this wrong entry.

The probe created to rediscover the region checks the region info from cached region first like other RPCs and this prevents invalidating the wrong region immediately. 

The fix here forces the HBaseClient to hit hbase meta data always, for such probes, to get the region info. With this fix we never seen TSDBs stuck NSREing during region splits. Tested this by asking HBASE to split region via hbase shell, which created an NSRE spike and the TSDBs was able recover from this very quickly.
