### PR TITLE
Fix compatibility issue with 0.96 (CDH5).

### DIFF
--- a/src/Scanner.java
+++ b/src/Scanner.java
@@ -1447,6 +1447,7 @@ public final class Scanner {
       final ScanRequest req = ScanRequest.newBuilder()
         .setScannerId(scanner_id)
         .setCloseScanner(true)
+        .setNumberOfRows(0)
         .build();
       return toChannelBuffer(SCAN, req);
     }

--- a/test/TestIntegration.java
+++ b/test/TestIntegration.java
@@ -290,6 +290,34 @@ final public class TestIntegration {
     }
   }
 
+  /** Scan which closes before reaching end of results. */
+  @Test
+  public void scanCloseEarly() throws Exception {
+    client.setFlushInterval(FAST_FLUSH);
+    final PutRequest put1 = new PutRequest(table, "s1", family, "q", "v1");
+    final PutRequest put2 = new PutRequest(table, "s2", family, "q", "v2");
+    Deferred.group(client.put(put1), client.put(put2)).join();
+    // Scan for the first row twice.
+    for (int i = 0; i < 2; i++) {
+      LOG.info("------------ iteration #" + i);
+      final Scanner scanner = client.newScanner(table);
+      scanner.setStartKey("s0");
+      scanner.setStopKey("s3");
+      try {
+        final ArrayList<ArrayList<KeyValue>> rows = scanner.nextRows(1).join();
+        assertSizeIs(1, rows);
+        final ArrayList<KeyValue> kvs = rows.get(0);
+        final KeyValue kv = kvs.get(0);
+        assertSizeIs(1, kvs);
+        assertEq("s1", kv.key());
+        assertEq("q", kv.qualifier());
+        assertEq("v1", kv.value());
+      } finally {
+        scanner.close().join();
+      }
+    }
+  }
+
   /** Scan with multiple qualifiers. */
   @Test
   public void scanWithQualifiers() throws Exception {


### PR DESCRIPTION
In the latest version of CDH5 (0.96.1.1+cdh5.0.2), the asynchbase client
fails if closing a scanner while there are still rows to be read.
Specifying numberOfRows == 0 avoids the issue (this matches the behavior
in the HBase synchronous client).

Without this fix, the client fails processing the close response with
the error:

    org.hbase.async.InvalidResponseException: Should not have gotten any
    cell blocks, yet there are [num] bytes that follow the protobuf
    response.  This should never happen.  Are you using an incompatible
    version of HBase?