### PR TITLE
Fix the hanging OpenTSDB bug after a restart of HBase region servers.

### DIFF
--- a/src/HBaseClient.java
+++ b/src/HBaseClient.java
@@ -1922,6 +1922,7 @@ public final class HBaseClient {
                                                              final byte[] key) {
     return new Callback<Object, Exception>() {
       public Object call(final Exception e) {
+        LOG.debug("locateRegion failed", e);
         if (e instanceof TableNotFoundException) {
           return new TableNotFoundException(table);  // Populate the name.
         } else if (e instanceof RecoverableException) {
@@ -2165,6 +2166,14 @@ public final class HBaseClient {
       // TODO: Resolve the race condition among {@link #ip2client},
       // {@link #client2regions}, {@link #region2client}, {@link #rootregion},
       // and {@link #regions_cache}.
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Lost a race while trying to" +
+                  (oldclient == null ? "add" : "replace") +
+                  " client for region " + region + ", which was " +
+                  (oldregion == null ? "added to" : "updated in") + " the" +
+                  " regions cache. The new client " + client + " is hosting " +
+                  " no regions.");
+      }
       return null;
     }
 
@@ -2467,6 +2476,8 @@ public final class HBaseClient {
       public Object call(final Object arg) {
         if (arg instanceof Exception) {
           LOG.warn("Probe " + probe + " failed", (Exception) arg);
+        } else {
+          LOG.debug("Probe {} was successful", probe);
         }
         ArrayList<HBaseRpc> removed = got_nsre.remove(region_name);
         if (removed != rpcs && removed != null) {  // Should never happen.

--- a/src/RegionClient.java
+++ b/src/RegionClient.java
@@ -201,6 +201,8 @@ final class RegionClient extends ReplayingDecoder<VoidEnum> {
     }
   };
 
+  // Debug id to follow log messages from the same RegionClient instance.
+  private final String dbg_instance_id;
   /**
    * Semaphore used to rate-limit META lookups and prevent "META storms".
    * <p>
@@ -216,6 +218,7 @@ final class RegionClient extends ReplayingDecoder<VoidEnum> {
    */
   public RegionClient(final HBaseClient hbase_client) {
     this.hbase_client = hbase_client;
+    this.dbg_instance_id = "@" + hashCode();
   }
 
   /**
@@ -433,7 +436,7 @@ final class RegionClient extends ReplayingDecoder<VoidEnum> {
     if (chancopy == null) {
       return Deferred.fromResult(null);
     }
-    LOG.debug("Shutdown requested, chan={}", chancopy);
+    LOG.debug("{} Shutdown requested, chan={}", dbg_instance_id, chancopy);
     if (chancopy.isConnected()) {
       Channels.disconnect(chancopy);   // ... this is going to set it to null.
       // At this point, all in-flight RPCs are going to be failed.
@@ -538,6 +541,8 @@ final class RegionClient extends ReplayingDecoder<VoidEnum> {
           // running HBase 0.92 or above, but using a pre-0.92 handshake.  So
           // we know we have to handshake differently.
           server_version = SERVER_VERSION_092_OR_ABOVE;
+          LOG.info("{} ProtocolVersionCB: retry helloRpc with header092",
+                   RegionClient.this.dbg_instance_id);
           helloRpc(chan, header092());
         } else {
           // We get here if the server refused our 0.92-style handshake.  This
@@ -573,6 +578,7 @@ final class RegionClient extends ReplayingDecoder<VoidEnum> {
     // The following line will make this client no longer queue incoming
     // RPCs, as we're now ready to communicate with the server.
     this.chan = chan;  // Volatile write.
+    LOG.debug("becomeReady {}", this);
     sendQueuedRpcs();
   }
 
@@ -814,8 +820,9 @@ final class RegionClient extends ReplayingDecoder<VoidEnum> {
           return e;  // Can't recover from this error, let it propagate.
         }
         if (LOG.isDebugEnabled()) {
-          LOG.debug("Multi-action request failed, retrying each of the "
-                    + request.size() + " RPCs individually.", e);
+          LOG.debug(dbg_instance_id + " Multi-action request failed, " +
+                    "retrying each of the " + request.size() +
+                    " RPCs individually.", e);
         }
         for (final BatchableRpc rpc : request.batch()) {
           retryEdit(rpc, (RecoverableException) e);
@@ -940,7 +947,7 @@ final class RegionClient extends ReplayingDecoder<VoidEnum> {
       sendRpc(rpc);
       return;
     }
-    LOG.debug("RPC queued: {}", rpc);
+    LOG.debug("{} RPC queued: {}", dbg_instance_id, rpc);
   }
 
   /**
@@ -979,12 +986,15 @@ final class RegionClient extends ReplayingDecoder<VoidEnum> {
     if (!hbase_client.has_root) {
       header = header095();
       Channels.write(chan, header);
+      LOG.debug("{} Connected to HBase 0.95 and up.", dbg_instance_id);
       becomeReady(chan, SERVER_VERSION_095_OR_ABOVE);
       return;
     } else if (System.getProperty("org.hbase.async.cdh3b3") != null) {
       header = headerCDH3b3();
+      LOG.debug("{} Connected to CDH3b3.", dbg_instance_id);
     } else {
       header = header090();
+      LOG.debug("{} Connected to HBase0.94 and down.", dbg_instance_id);
     }
     helloRpc(chan, header);
   }
@@ -1003,7 +1013,7 @@ final class RegionClient extends ReplayingDecoder<VoidEnum> {
     }
     if (rpcs != null) {
       for (final HBaseRpc rpc : rpcs) {
-        LOG.debug("Executing RPC queued: {}", rpc);
+        LOG.debug("{} Executing RPC queued: {}", dbg_instance_id, rpc);
         sendRpc(rpc);
       }
     }
@@ -1012,6 +1022,7 @@ final class RegionClient extends ReplayingDecoder<VoidEnum> {
   @Override
   public void channelDisconnected(final ChannelHandlerContext ctx,
                                   final ChannelStateEvent e) throws Exception {
+    LOG.debug("{} channelDisconnected: {}", dbg_instance_id, chan);
     chan = null;
     super.channelDisconnected(ctx, e);  // Let the ReplayingDecoder cleanup.
     cleanup(e.getChannel());
@@ -1020,6 +1031,7 @@ final class RegionClient extends ReplayingDecoder<VoidEnum> {
   @Override
   public void channelClosed(final ChannelHandlerContext ctx,
                             final ChannelStateEvent e) {
+    LOG.debug("{} channelClosed: {}", dbg_instance_id, chan);
     chan = null;
     // No need to call super.channelClosed() because we already called
     // super.channelDisconnected().  If we get here without getting a
@@ -1084,7 +1096,7 @@ final class RegionClient extends ReplayingDecoder<VoidEnum> {
   public void handleUpstream(final ChannelHandlerContext ctx,
                              final ChannelEvent e) throws Exception {
     if (LOG.isDebugEnabled()) {
-      LOG.debug("handleUpstream {}", e);
+      LOG.debug("{} handleUpstream {}", dbg_instance_id, e);
     }
     super.handleUpstream(ctx, e);
   }
@@ -1096,10 +1108,11 @@ final class RegionClient extends ReplayingDecoder<VoidEnum> {
     final Channel c = event.getChannel();
 
     if (e instanceof RejectedExecutionException) {
-      LOG.warn("RPC rejected by the executor,"
+      LOG.warn(dbg_instance_id + " RPC rejected by the executor,"
                + " ignore this if we're shutting down", e);
     } else {
-      LOG.error("Unexpected exception from downstream on " + c, e);
+      LOG.error(dbg_instance_id + " Unexpected exception from downstream on " +
+                c, e);
     }
     if (c.isOpen()) {
       Channels.close(c);  // Will trigger channelClosed(), which will cleanup()
@@ -1215,7 +1228,8 @@ final class RegionClient extends ReplayingDecoder<VoidEnum> {
         payload.setBytes(10, method);                   // method.length bytes
       }
     } catch (Exception e) {
-      LOG.error("Uncaught exception while serializing RPC: " + rpc, e);
+      LOG.error(dbg_instance_id + " Uncaught exception while serializing RPC: " +
+                rpc, e);
       rpc.callback(e);  // Make the RPC fail with the exception.
       return null;
     }
@@ -1227,8 +1241,8 @@ final class RegionClient extends ReplayingDecoder<VoidEnum> {
     // fewer, bigger TCP packets, and make better use of the network.
 
     if (LOG.isDebugEnabled()) {
-      LOG.debug(chan + " Sending RPC #" + rpcid + ", payload=" + payload + ' '
-                + Bytes.pretty(payload));
+      LOG.debug(dbg_instance_id + " " + chan + " Sending RPC #" + rpcid +
+                ", payload=" + payload + ' ' + Bytes.pretty(payload));
     }
     {
       final HBaseRpc oldrpc = rpcs_inflight.put(rpcid, rpc);
@@ -1286,8 +1300,8 @@ final class RegionClient extends ReplayingDecoder<VoidEnum> {
     final HBaseRpc rpc = rpcs_inflight.get(rpcid);
 
     if (rpc == null) {
-      final String msg = "Invalid rpcid: " + rpcid + " found in "
-        + buf + '=' + Bytes.pretty(buf);
+      final String msg = dbg_instance_id + " Invalid rpcid: " + rpcid +
+          " found in " + buf + '=' + Bytes.pretty(buf);
       LOG.error(msg);
       // The problem here is that we don't know which Deferred corresponds to
       // this RPC, since we don't have a valid ID.  So we're hopeless, we'll
@@ -1321,8 +1335,8 @@ final class RegionClient extends ReplayingDecoder<VoidEnum> {
         decoded = deserialize(buf, rpc);
       }
     } catch (RuntimeException e) {
-      final String msg = "Uncaught error during de-serialization of " + rpc
-        + ", rpcid=" + rpcid;
+      final String msg = dbg_instance_id + "Uncaught error during de-serialization of "
+        + rpc + ", rpcid=" + rpcid;
       LOG.error(msg);
       if (!(e instanceof HBaseException)) {
         e = new NonRecoverableException(msg, e);
@@ -1332,7 +1346,7 @@ final class RegionClient extends ReplayingDecoder<VoidEnum> {
     }
 
     if (LOG.isDebugEnabled()) {
-      LOG.debug("rpcid=" + rpcid
+      LOG.debug(dbg_instance_id + " rpcid=" + rpcid
                 + ", response size=" + (buf.readerIndex() - rdx) + " bytes"
                 + ", " + actualReadableBytes() + " readable bytes left"
                 + ", rpc=" + rpc);
@@ -1357,8 +1371,8 @@ final class RegionClient extends ReplayingDecoder<VoidEnum> {
     try {
       rpc.callback(decoded);
     } catch (Exception e) {
-      LOG.error("Unexpected exception while handling RPC #" + rpcid
-                + ", rpc=" + rpc + ", buf=" + Bytes.pretty(buf), e);
+      LOG.error(dbg_instance_id + " Unexpected exception while handling RPC #" +
+                rpcid + ", rpc=" + rpc + ", buf=" + Bytes.pretty(buf), e);
     }
     if (LOG.isDebugEnabled()) {
       LOG.debug("------------------<< LEAVING  DECODE <<------------------"
@@ -1450,6 +1464,8 @@ final class RegionClient extends ReplayingDecoder<VoidEnum> {
   private static final HBaseException makeException(final HBaseRpc request,
                                                     final String type,
                                                     final String msg) {
+    LOG.debug("makeException: type = {}, msg = {}, request = {}",
+              type, msg, request);
     final HBaseException exc = REMOTE_EXCEPTION_TYPES.get(type);
     if (exc != null) {
       return exc.make(msg, request);
@@ -1676,7 +1692,8 @@ final class RegionClient extends ReplayingDecoder<VoidEnum> {
         return decode(ctx, chan, buf, unused);
       } finally {
         if (buf.readable()) {
-          LOG.error("After decoding the last message on " + chan
+          LOG.error(dbg_instance_id + " After decoding the last message on "
+                    + chan
                     + ", there was still some undecoded bytes in the channel's"
                     + " buffer (which are going to be lost): "
                     + buf + '=' + Bytes.pretty(buf));
@@ -1845,12 +1862,13 @@ final class RegionClient extends ReplayingDecoder<VoidEnum> {
    * @param header The header to use for the handshake.
    */
   private void helloRpc(final Channel new_chan, final ChannelBuffer header) {
-    LOG.debug("helloRpc for the channel: {}", new_chan);
+    LOG.debug("{} helloRpc for the channel: {}", dbg_instance_id, new_chan);
     Callback<Object, Exception> errorback = new Callback<Object, Exception>() {
 
       @Override
       public Object call(final Exception e) throws Exception {
-        LOG.info("helloRpc failed. Closing the channel:" + new_chan, e);
+        LOG.info(dbg_instance_id + " helloRpc failed. Closing the channel:" +
+                 new_chan, e);
         Channels.close(new_chan);
         return e;
       }


### PR DESCRIPTION
The bug existed with HBase versions lower than 0.95. The bug was that
ProtocolVersionCB of RegionClient did not properly handle exceptions like
ServerNotRunningYetException during a HBase restart. The side effect was that
neither the becomeReady nor the cleanup method of the corresponding region
client was called because the channel was already connected and healthy. As a
result, any attempt of sending requests to the region server via sendRpc ended
up accumulating the requests to the pending_rpcs. The fix was closing the
corresponding channel when ProtocolVersionCB gets an exception. Also more
loggings were added that were useful for debugging this bug.