### PR TITLE
Make RegionMovedException subtype of NSRE

### DIFF
--- a/src/NotServingRegionException.java
+++ b/src/NotServingRegionException.java
@@ -30,7 +30,7 @@ package org.hbase.async;
  * Exception thrown when we attempted to use a region that wasn't serving from
  * that particular RegionServer.  It probably moved somewhere else.
  */
-public final class NotServingRegionException extends RecoverableException
+public class NotServingRegionException extends RecoverableException
 implements HasFailedRpcException {
 
   static final String REMOTE_CLASS =

--- a/src/RegionClient.java
+++ b/src/RegionClient.java
@@ -1336,8 +1336,7 @@ final class RegionClient extends ReplayingDecoder<VoidEnum> {
       assert rpc == removed;
     }
 
-    if ((decoded instanceof NotServingRegionException ||
-         decoded instanceof RegionMovedException)
+    if (decoded instanceof NotServingRegionException
         && rpc.getRegion() != null) {
       // We only handle NSREs for RPCs targeted at a specific region, because
       // if we don't know which region caused the NSRE (e.g. during multiPut)

--- a/src/RegionMovedException.java
+++ b/src/RegionMovedException.java
@@ -31,7 +31,7 @@ package org.hbase.async;
  * that particular RegionServer to a new one.
  * @since 1.6
  */
-public final class RegionMovedException extends RecoverableException
+public final class RegionMovedException extends NotServingRegionException
 implements HasFailedRpcException {
 
   static final String REMOTE_CLASS =
@@ -45,7 +45,7 @@ implements HasFailedRpcException {
    * @param failed_rpc The RPC that caused this exception, if known, or null.
    */
   RegionMovedException(final String msg, final HBaseRpc failed_rpc) {
-    super(msg);
+    super(msg, failed_rpc);
     this.failed_rpc = failed_rpc;
   }
 
@@ -69,5 +69,5 @@ implements HasFailedRpcException {
     return new RegionMovedException(msg.toString(), rpc);
   }
 
-  private static final long serialVersionUID = 1411866342;
+  private static final long serialVersionUID = -5340447708638974493L;
 }


### PR DESCRIPTION
If a region has been moved away from a region server, it
is semantically also an NSRE. It therefore makes sense
to have RegionMovedException as a subtype of NotServingRegionException.
This is also the case in default hbase-client.