### PR TITLE
Support atomic increment with multiple columns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build/
 pom.xml
 target/
 /bin/
+.idea

--- a/Makefile
+++ b/Makefile
@@ -61,12 +61,14 @@ BUILT_SOURCES := $(asynchbase_PROTOS:protobuf/%.proto=$(PROTOBUF_GEN_DIR)/%PB.ja
 asynchbase_SOURCES := \
 	src/AppendRequest.java	\
 	src/AtomicIncrementRequest.java	\
+	src/MultiColumnAtomicIncrementRequest.java	\
 	src/BatchableRpc.java	\
 	src/BinaryComparator.java	\
 	src/BinaryPrefixComparator.java	\
 	src/BitComparator.java	\
 	src/BrokenMetaException.java	\
 	src/BufferedIncrement.java	\
+	src/BufferedMultiColumnIncrement.java	\
 	src/Bytes.java	\
 	src/ClientStats.java	\
 	src/ColumnPaginationFilter.java	\

--- a/src/BufferedMultiColumnIncrement.java
+++ b/src/BufferedMultiColumnIncrement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012  The Async HBase Authors.  All rights reserved.
+ * Copyright (C) 2016  The Async HBase Authors.  All rights reserved.
  * This file is part of Async HBase.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,7 +26,12 @@
  */
 package org.hbase.async;
 
-import com.google.common.cache.*;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.CacheStats;
+import com.google.common.cache.LoadingCache;
+import com.google.common.cache.RemovalListener;
+import com.google.common.cache.RemovalNotification;
 import com.stumbleupon.async.Deferred;
 
 import java.util.Arrays;
@@ -35,7 +40,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Package-private class to uniquely identify a buffered multi-column atomic increment.
- * @since 1.7.1
+ * @since 1.8
  */
 final class BufferedMultiColumnIncrement {
 
@@ -44,7 +49,7 @@ final class BufferedMultiColumnIncrement {
       return false;
     }
     for (int i = 0; i < self.length; i++) {
-      if (!Bytes.equals(self[i], other[i])) {
+      if (Bytes.memcmp(self[i], other[i]) != 0) {
         return false;
       }
     }
@@ -363,7 +368,7 @@ final class BufferedMultiColumnIncrement {
         final MultiColumnAtomicIncrementRequest req =
             new MultiColumnAtomicIncrementRequest(incr.table, incr.key, incr.family,
                 incr.qualifiers, delta);
-        client.atomicIncrements(req).chain(amounts.deferred);
+        client.atomicIncrement(req).chain(amounts.deferred);
       }
     }
 

--- a/src/BufferedMultiColumnIncrement.java
+++ b/src/BufferedMultiColumnIncrement.java
@@ -1,0 +1,374 @@
+/*
+ * Copyright (C) 2012  The Async HBase Authors.  All rights reserved.
+ * This file is part of Async HBase.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   - Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *   - Neither the name of the StumbleUpon nor the names of its contributors
+ *     may be used to endorse or promote products derived from this software
+ *     without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hbase.async;
+
+import com.google.common.cache.*;
+import com.stumbleupon.async.Deferred;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Package-private class to uniquely identify a buffered multi-column atomic increment.
+ * @since 1.7.1
+ */
+final class BufferedMultiColumnIncrement {
+
+  private static boolean byteArrayEquals(byte[][] self, byte[][] other) {
+    if (self.length != other.length) {
+      return false;
+    }
+    for (int i = 0; i < self.length; i++) {
+      if (!Bytes.equals(self[i], other[i])) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static int byteArrayHashCode(byte[][] self) {
+    int hashCode = 1;
+    for (byte[] aSelf : self) {
+      hashCode = Arrays.hashCode(aSelf) + 41 * hashCode;
+    }
+    return hashCode;
+  }
+
+  private static int byteArrayLength(byte[][] self) {
+    int len = 0;
+    for (byte[] aSelf : self) {
+      len += aSelf.length;
+    }
+    return len;
+  }
+
+  private static void byteArrayToString(StringBuilder sb, byte[][] self) {
+    for (byte[] aSelf : self) {
+      sb.append(Bytes.pretty(aSelf));
+    }
+  }
+
+  private final byte[] table;
+  private final byte[] key;
+  private final byte[] family;
+  private final byte[][] qualifiers;
+
+  BufferedMultiColumnIncrement(final byte[] table, final byte[] key,
+                               final byte[] family, final byte[][] qualifiers) {
+    this.table = table;
+    this.key = key;
+    this.family = family;
+    this.qualifiers = qualifiers;
+  }
+
+  public boolean equals(final Object other) {
+    if (other == null || !(other instanceof BufferedMultiColumnIncrement)) {
+      return false;
+    }
+    final BufferedMultiColumnIncrement incr = (BufferedMultiColumnIncrement) other;
+    // Compare fields most likely to be different first.
+    return Bytes.equals(key, incr.key)
+      && byteArrayEquals(qualifiers, incr.qualifiers)
+      && Bytes.equals(family, incr.family)
+      && Bytes.equals(table, incr.table);
+  }
+
+  public int hashCode() {
+    return
+      Arrays.hashCode(table) + 41 * (
+        Arrays.hashCode(key) + 41 * (
+          Arrays.hashCode(family) + 41 * (
+              byteArrayHashCode(qualifiers) + 41
+          )
+        )
+      );
+  }
+
+  public String toString() {
+    final StringBuilder buf =
+      new StringBuilder(52 + table.length + key.length * 2 + family.length
+                        + byteArrayLength(qualifiers));
+    buf.append("BufferedIncrement(table=");
+    Bytes.pretty(buf, table);
+    buf.append(", key=");
+    Bytes.pretty(buf, key);
+    buf.append(", family=");
+    Bytes.pretty(buf, family);
+    buf.append(", qualifier=");
+    byteArrayToString(buf, qualifiers);
+    buf.append(')');
+    return buf.toString();
+  }
+
+  /**
+   * Atomic increment amounts.
+   * <p>
+   * This behaves like a signed 49 bit atomic integer that
+   * can only be incremented/decremented a specific number
+   * of times.  The {@link #update} method must be used
+   * for all increment/decrement operations, as the underlying
+   * raw value of the {@code long} from {@link AtomicLong} is
+   * not the value of the counter, as some of its bits are
+   * reserved to keep track of how many times the value
+   * got changed.
+   * <p>
+   * Implementation details:<br/>
+   * The first 49 most significant bits are the value of
+   * the amount (including 1 bit for the sign), the last
+   * 15 least significant bits are the number of times
+   * left that {@link #update} can be called.
+   * <p>
+   * Again, this class opportunistically inherits from
+   * {@link AtomicLong}, but <strong>don't call methods
+   * from the parent class directly</strong>.
+   */
+  static final class Amounts  {
+
+    /** Number of least-significant bits (LSB) we reserve to track updates.  */
+    private final static int UPDATE_BITS = 15;
+    /** Mask used to retrieve number of updates left (0x0000000000007FFFL).  */
+    private final static long UPDATE_MASK = (1L << UPDATE_BITS) - 1;
+    /** Mask used to get value bits we can't store (0xFFFF000000000000L).  */
+    private final static long OVERFLOW_MASK = (UPDATE_MASK << (64 - UPDATE_BITS)
+                                               >> 1); // Reserve the sign bit.
+
+    final AtomicLong[] values;
+
+    /** Everyone waiting for this increment is queued up here.  */
+    final Deferred<Map<byte[], Long>> deferred = new Deferred<Map<byte[], Long>>();
+
+    /**
+     * Creates a new atomic amount.
+     * @param max_updates The maximum number of times {@link #update}
+     * can be called.  Beyond this number of calls, the method will return
+     * {@code false}.
+     */
+    Amounts(final short max_updates, final int numColumns) {
+      assert max_updates > 0 : "WTF: max_updates=" + max_updates;
+      values = new AtomicLong[numColumns];
+      for(int i = 0; i < numColumns; i++) {
+        values[i] = new AtomicLong(max_updates);
+      }
+    }
+
+    /**
+     * Atomically updates this amount.
+     * @param delta The delta by which to increment the value.
+     * Of course, if the delta value is negative, the value will be
+     * decremented instead.
+     * @return {@code true} if the update could be done, {@code false} if
+     * it couldn't due to an overflow/underflow or due to reaching the
+     * maximum number of times this Amount could be incremented.
+     */
+    final boolean update(final long[] delta) {
+      assert (delta.length == values.length);
+
+      boolean okToUpdate = true;
+      for(int i = 0; i < delta.length && okToUpdate; i++) {
+        while (true) {
+          final long current = values[i].get();
+          final int updates = numUpdatesLeft(current);
+          if (updates == 0) {
+            okToUpdate = false;
+            break;  // Already too many increments.
+          }
+          final long new_amount = amount(current) + delta[i];
+          if (!checkOverflow(new_amount)) {
+            okToUpdate = false;
+            break;  // Overflow, new amount doesn't fit on 49 bits.
+          }
+          final long next = (new_amount << UPDATE_BITS) | (updates - 1);
+          if (values[i].compareAndSet(current, next)) {
+            // we need to reset it to 0. In case it is a partial failure, the value that has been
+            // successfully applied won't be inc'ed again
+            delta[i] = 0L;
+            break;
+          }
+          // else: CAS failed, loop again.
+        }
+      }
+      return okToUpdate;
+    }
+
+    /**
+     * Atomically sets the number of updates left to 0 and return the value.
+     * @return The raw value, not the amount by which to increment.
+     * To get the raw value, use {@link #amount} on the value returned.
+     */
+    final long[] getRawAndInvalidate() {
+      long[] currents = new long[values.length];
+      for(int i = 0; i < currents.length; i++) {
+        while (true) {
+          final long current = values[i].get();
+          // Technically, we could leave the whole value set to 0 here, but
+          // to help when debugging with toString(), we restore the amount.
+          final long next = amount(current) << UPDATE_BITS;
+          if (values[i].compareAndSet(current, next)) {  // => sets updates left to 0.
+            currents[i] = current;
+            break;
+          }
+          // else: CAS failed, loop again.
+        }
+      }
+      return currents;
+    }
+
+    /** The amount by which we're going to increment the value in HBase.  */
+    static final long amount(final long n) {
+      return n >> UPDATE_BITS;
+    }
+
+    /** The number of times left that this amount can be updated.  */
+    static final int numUpdatesLeft(final long n) {
+      return (int) (n & UPDATE_MASK);
+    }
+
+    /**
+     * Returns {@code true} if the given value can fit without overflowing.
+     */
+    static final boolean checkOverflow(final long value) {
+      // If the amount was positive, then the MSBs must remain 0.  Any 1 in
+      // the MSBs would indicate that the value has become too big or has
+      // become negative due to an overflow.  Similarly, if the amount was
+      // negative, then MSBs must remain 1.
+      final long masked = value & OVERFLOW_MASK;
+      return masked == 0 || masked == OVERFLOW_MASK;
+    }
+
+    public String toString() {
+      long[] currents = new long[values.length];
+      StringBuilder sb = new StringBuilder();
+
+      sb.append("Amounts: ");
+      for(int i = 0; i < values.length; i++) {
+        currents[i] = values[i].get();
+        sb.append(amount(currents[i]));
+        sb.append("|");
+        sb.append(numUpdatesLeft(currents[i]));
+        sb.append(",");
+      }
+      sb.append("Deferred: ");
+      sb.append(deferred);
+      return sb.toString();
+    }
+
+    private static final long serialVersionUID = 1333868962;
+  }
+
+  /**
+   * Creates a new cache for buffered increments.
+   * @param client The client to work with.
+   * @param size Max number of entries of the cache.
+   */
+  static LoadingCache<BufferedMultiColumnIncrement, Amounts>
+    newCache(final HBaseClient client, final int size) {
+    final int ncpu = Runtime.getRuntime().availableProcessors();
+    return CacheBuilder.newBuilder()
+      // Beef up the concurrency level as this is the number of internal
+      // segments used by the hash map.  The default is 4, which is not enough
+      // for us as we typically have more than that many threads concurrently
+      // accessing the map.  Because Guava's LocalCache maintains a
+      // per-segment buffer of access operations not yet committed, having a
+      // few more segments than we actually need helps increase the number of
+      // read operations we can do on a segment of the map with no interleaved
+      // writes before the segment has to acquire the lock to flush the buffer.
+      // We can't control this otherwise, because it's a hard-coded constant
+      // in LocalCache.DRAIN_THRESHOLD = 0x3F = 63;
+      // In addition, through benchmarking on a heavily contended cache, I saw
+      // that increasing the number of segments (4x to 8x number of hardware
+      // threads) can help significantly boost overall throughput.
+      .concurrencyLevel(ncpu * 4)
+      .maximumSize(size)
+      .recordStats()  // As of Guava 12, stats are disabled by default.
+      .removalListener(new EvictionHandler(client))
+      .build(LOADER);
+  }
+
+  /** Creates new zero-Amount for new BufferedIncrements.  */
+  static final class Loader extends CacheLoader<BufferedMultiColumnIncrement, Amounts> {
+
+    /**
+     * Max number of increments/decrements per counter before we force-flush.
+     * This limit is comes from the max callback chain length on a Deferred.
+     */
+    private static final short MAX_UPDATES = 16383;
+
+    @Override
+    public Amounts load(final BufferedMultiColumnIncrement key) {
+      return new Amounts(MAX_UPDATES, key.qualifiers.length);
+    }
+
+  }
+
+  /** Singleton instance.  */
+  private static final Loader LOADER = new Loader();
+
+  /** Handles cache evictions (also called on flushes).  */
+  private static final class EvictionHandler
+    implements RemovalListener<BufferedMultiColumnIncrement, Amounts> {
+
+    private final HBaseClient client;
+
+    EvictionHandler(final HBaseClient client) {
+      this.client = client;
+    }
+
+    @Override
+    public void onRemoval(final RemovalNotification<BufferedMultiColumnIncrement, Amounts> entry) {
+
+      final Amounts amounts = entry.getValue();
+      assert(amounts != null);
+
+      final long[] raw = amounts.getRawAndInvalidate();
+      final long[] delta = new long[raw.length];
+      boolean hasUpdates = false;
+      for(int i = 0; i < raw.length; i++) {
+        delta[i] = Amounts.amount(raw[i]);
+        if (Amounts.numUpdatesLeft(raw[i]) < Loader.MAX_UPDATES) {
+          // This amount was never incremented, because the number of updates
+          // left is still the original number.  Therefore this is an Amount
+          // that has been evicted before anyone could attach any update to
+          // it, so the delta must be 0, and we don't need to send this RPC.
+          hasUpdates = true;
+        }
+      }
+
+      if (hasUpdates) {
+        final BufferedMultiColumnIncrement incr = entry.getKey();
+        final MultiColumnAtomicIncrementRequest req =
+            new MultiColumnAtomicIncrementRequest(incr.table, incr.key, incr.family,
+                incr.qualifiers, delta);
+        client.atomicIncrements(req).chain(amounts.deferred);
+      }
+    }
+
+  }
+
+  static final CacheStats ZERO_STATS = new CacheStats(0, 0, 0, 0, 0, 0);
+
+}

--- a/src/MultiColumnAtomicIncrementRequest.java
+++ b/src/MultiColumnAtomicIncrementRequest.java
@@ -1,0 +1,303 @@
+/*
+ * Copyright (C) 2010-2012  The Async HBase Authors.  All rights reserved.
+ * This file is part of Async HBase.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   - Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *   - Neither the name of the StumbleUpon nor the names of its contributors
+ *     may be used to endorse or promote products derived from this software
+ *     without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hbase.async;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.Maps;
+import org.hbase.async.generated.ClientPB.MutateRequest;
+import org.hbase.async.generated.ClientPB.MutateResponse;
+import org.hbase.async.generated.ClientPB.MutationProto;
+import org.jboss.netty.buffer.ChannelBuffer;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+
+/**
+ * Atomically increments several column values in HBase.
+ *
+ * <h1>A note on passing {@code byte} arrays in argument</h1>
+ * None of the method that receive a {@code byte[]} in argument will copy it.
+ * For more info, please refer to the documentation of {@link HBaseRpc}.
+ * <h1>A note on passing {@code String}s in argument</h1>
+ * All strings are assumed to use the platform's default charset.
+ */
+public final class MultiColumnAtomicIncrementRequest extends HBaseRpc
+  implements HBaseRpc.HasTable, HBaseRpc.HasKey,
+             HBaseRpc.HasFamily, HBaseRpc.HasQualifiers, HBaseRpc.IsEdit {
+
+  private static byte[][] toByteArrays(String[] strArray) {
+    byte[][] converted = new byte[strArray.length][];
+    for(int i = 0; i < strArray.length; i++) {
+      converted[i] = strArray[i].getBytes();
+    }
+    return converted;
+  }
+
+  private static final byte[] INCREMENT_COLUMN_VALUE = new byte[] {
+    'i', 'n', 'c', 'r', 'e', 'm', 'e', 'n', 't',
+    'C', 'o', 'l', 'u', 'm', 'n',
+    'V', 'a', 'l', 'u', 'e'
+  };
+
+  private static final Joiner AMOUNT_JOINER = Joiner.on(",");
+
+  private final byte[] family;
+  private final byte[][] qualifiers;
+  private long[] amounts;
+  private boolean durable = true;
+
+  /**
+   * Constructor.
+   * <strong>These byte arrays will NOT be copied.</strong>
+   * @param table The non-empty name of the table to use.
+   * @param key The row key of the value to increment.
+   * @param family The column family of the value to increment.
+   * @param qualifiers The column qualifier of the value to increment.
+   * @param amounts Amount by which to increment the value in HBase.
+   * If negative, the value in HBase will be decremented.
+   */
+  public MultiColumnAtomicIncrementRequest(final byte[] table,
+                                           final byte[] key,
+                                           final byte[] family,
+                                           final byte[][] qualifiers,
+                                           final long[] amounts) {
+    super(table, key);
+    KeyValue.checkFamily(family);
+    this.family = family;
+
+    if (qualifiers == null || qualifiers.length == 0) {
+      throw new IllegalArgumentException("qualifiers must be provided for MultiColumnAtomicIncrementRequest");
+    }
+    for (byte[] qualifier : qualifiers) {
+      KeyValue.checkQualifier(qualifier);
+    }
+    this.qualifiers = qualifiers;
+
+    if (amounts != null) {
+      if (amounts.length == 0) {
+        throw new IllegalArgumentException("amounts must be provided for MultiColumnAtomicIncrementRequest");
+      }
+      if (qualifiers.length != amounts.length) {
+        throw new IllegalArgumentException("Number of amounts must be equal to the number of qualifiers provided for MultiColumnAtomicIncrementRequest");
+      }
+      this.amounts = amounts;
+
+    } else {
+      this.amounts = new long[qualifiers.length];
+      Arrays.fill(this.amounts, 1L);
+    }
+  }
+
+  /**
+   * Constructor.  This is equivalent to:
+   * {@link #MultiColumnAtomicIncrementRequest(byte[], byte[], byte[], byte[][], long[])
+   * MultiColumnAtomicIncrementRequest}{@code (table, key, family, qualifiers, new long[] {1, ..})}
+   * <p>
+   * <strong>These byte arrays will NOT be copied.</strong>
+   * @param table The non-empty name of the table to use.
+   * @param key The row key of the value to increment.
+   * @param family The column family of the value to increment.
+   * @param qualifiers The column qualifier of the value to increment.
+   */
+  public MultiColumnAtomicIncrementRequest(final byte[] table,
+                                           final byte[] key,
+                                           final byte[] family,
+                                           final byte[][] qualifiers) {
+    this(table, key, family, qualifiers, null);
+  }
+
+  /**
+   * Constructor.
+   * All strings are assumed to use the platform's default charset.
+   * @param table The non-empty name of the table to use.
+   * @param key The row key of the value to increment.
+   * @param family The column family of the value to increment.
+   * @param qualifiers The column qualifier of the value to increment.
+   * @param amounts Amount by which to increment the value in HBase.
+   * If negative, the value in HBase will be decremented.
+   */
+  public MultiColumnAtomicIncrementRequest(final String table,
+                                           final String key,
+                                           final String family,
+                                           final String[] qualifiers,
+                                           final long[] amounts) {
+    this(table.getBytes(), key.getBytes(), family.getBytes(),
+        toByteArrays(qualifiers), amounts);
+  }
+
+  /**
+   * Constructor.  This is equivalent to:
+   * All strings are assumed to use the platform's default charset.
+   * {@link #MultiColumnAtomicIncrementRequest(String, String, String, String[], long[])
+   * MultiColumnAtomicIncrementRequest}{@code (table, key, family, qualifiers, new long[]{ 1, ..})}
+   * @param table The non-empty name of the table to use.
+   * @param key The row key of the value to increment.
+   * @param family The column family of the value to increment.
+   * @param qualifiers The column qualifier of the value to increment.
+   */
+  public MultiColumnAtomicIncrementRequest(final String table,
+                                           final String key,
+                                           final String family,
+                                           final String[] qualifiers) {
+    this(table.getBytes(), key.getBytes(), family.getBytes(),
+         toByteArrays(qualifiers), null);
+  }
+
+  /**
+   * Returns the amount by which the value is going to be incremented.
+   */
+  public long[] getAmounts() {
+    return amounts;
+  }
+
+  /**
+   * Changes the amounts by which the values are going to be incremented.
+   * @param amounts The new amounts.  If negative, the value will be decremented.
+   */
+  public void setAmounts(final long[] amounts) {
+    this.amounts = amounts;
+  }
+
+  @Override
+  byte[] method(final byte server_version) {
+    return (server_version >= RegionClient.SERVER_VERSION_095_OR_ABOVE
+            ? MUTATE
+            : INCREMENT_COLUMN_VALUE);
+  }
+
+  @Override
+  public byte[] table() {
+    return table;
+  }
+
+  @Override
+  public byte[] key() {
+    return key;
+  }
+
+  @Override
+  public byte[] family() {
+    return family;
+  }
+
+  @Override
+  public byte[][] qualifiers() {
+    return qualifiers;
+  }
+
+  public String toString() {
+    return super.toStringWithQualifiers("MultiColumnAtomicIncrementRequest",
+        family, qualifiers, null, ", amounts=" + AMOUNT_JOINER.join(Arrays.asList(amounts)));
+  }
+
+  // ---------------------- //
+  // Package private stuff. //
+  // ---------------------- //
+
+  /**
+   * Changes whether or not this atomic increment should use the WAL.
+   * @param durable {@code true} to use the WAL, {@code false} otherwise.
+   */
+  void setDurable(final boolean durable) {
+    this.durable = durable;
+  }
+
+  private int predictSerializedSize() {
+    int size = 0;
+    size += 4;  // int:  Number of parameters.
+    size += 1;  // byte: Type of the 1st parameter.
+    size += 3;  // vint: region name length (3 bytes => max length = 32768).
+    size += region.name().length;  // The region name.
+    size += 1;  // byte: Type of the 2nd parameter.
+    size += 3;  // vint: row key length (3 bytes => max length = 32768).
+    size += key.length;  // The row key.
+    size += 1;  // byte: Type of the 3rd parameter.
+    size += 1;  // vint: Family length (guaranteed on 1 byte).
+    size += family.length;  // The family.
+    size += 1;  // byte: Type of the 4th parameter.
+    size += 3;  // vint: Qualifier length.
+    for(byte[] qualifier : qualifiers) {
+      size += qualifier.length;  // The qualifier.
+    }
+    size += 1;  // byte: Type of the 5th parameter.
+    size += 8 * amounts.length;  // long: Amount.
+    size += 1;  // byte: Type of the 6th parameter.
+    size += 1;  // bool: Whether or not to write to the WAL.
+    return size;
+  }
+
+  /** Serializes this request.  */
+  ChannelBuffer serialize(final byte server_version) {
+    if (server_version < RegionClient.SERVER_VERSION_095_OR_ABOVE) {
+      throw new UnsupportedOperationException(server_version + " is not supported by " + this.getClass().getName());
+    }
+    MutationProto.Builder incr = MutationProto.newBuilder()
+      .setRow(Bytes.wrap(key))
+      .setMutateType(MutationProto.MutationType.INCREMENT);
+
+    for (int i = 0; i < qualifiers.length; i++) {
+      final MutationProto.ColumnValue.QualifierValue qualifier =
+        MutationProto.ColumnValue.QualifierValue.newBuilder()
+        .setQualifier(Bytes.wrap(this.qualifiers[i]))
+        .setValue(Bytes.wrap(Bytes.fromLong(this.amounts[i])))
+        .build();
+      final MutationProto.ColumnValue column =
+        MutationProto.ColumnValue.newBuilder()
+        .setFamily(Bytes.wrap(family))
+        .addQualifierValue(qualifier)
+        .build();
+      incr.addColumnValue(column);
+    }
+
+    if (!durable) {
+      incr.setDurability(MutationProto.Durability.SKIP_WAL);
+    }
+    final MutateRequest req = MutateRequest.newBuilder()
+      .setRegion(region.toProtobuf())
+      .setMutation(incr.build())
+      .build();
+    return toChannelBuffer(MUTATE, req);
+  }
+
+
+  @Override
+  Object deserialize(final ChannelBuffer buf, int cell_size) {
+    final MutateResponse resp = readProtobuf(buf, MutateResponse.PARSER);
+    // An increment must always produce a result, so we shouldn't need to
+    // check whether the `result' field is set here.
+    final ArrayList<KeyValue> kvs = GetRequest.convertResult(resp.getResult(),
+                                                             buf, cell_size);
+
+    Map<byte[], Long> updatedValues = Maps.newHashMap();
+    for (KeyValue kv : kvs) {
+      updatedValues.put(kv.qualifier(), Bytes.getLong(kv.value()));
+    }
+    return updatedValues;
+  }
+
+}

--- a/test/Common.java
+++ b/test/Common.java
@@ -31,7 +31,6 @@ import org.jboss.netty.logging.Slf4JLoggerFactory;
 import org.junit.Ignore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.hbase.async.HBaseClient;
 
 @Ignore // ignore for test runners
 final class Common {
@@ -56,7 +55,6 @@ final class Common {
     } else {
       zkquorum = "localhost";
     }
-    final HBaseClient client;
     if (args.length > 3) {
       return new HBaseClient(zkquorum, args[3]);
     } else {

--- a/test/Test.java
+++ b/test/Test.java
@@ -196,7 +196,7 @@ final class Test {
       }
       args = null;
       try {
-        final Map<byte[], Long> result = client.atomicIncrements(micv).joinUninterruptibly();
+        final Map<byte[], Long> result = client.atomicIncrement(micv).joinUninterruptibly();
         final String formatted = Joiner.on("->").withKeyValueSeparator(";").join(result);
         LOG.info("MICV result=" + formatted);
       } catch (Exception e) {

--- a/test/TestIntegration.java
+++ b/test/TestIntegration.java
@@ -41,6 +41,10 @@ import java.util.ArrayList;
 import java.util.Collection;
 
 import org.slf4j.Logger;
+import com.stumbleupon.async.Callback;
+import com.stumbleupon.async.Deferred;
+import com.stumbleupon.async.DeferredGroupException;
+import org.hbase.async.CompareFilter.CompareOp;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -51,47 +55,14 @@ import org.junit.runner.Result;
 import org.junit.runner.notification.Failure;
 import org.junit.runner.notification.RunListener;
 import org.powermock.reflect.Whitebox;
+import org.slf4j.Logger;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import java.io.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
 
-import com.stumbleupon.async.Callback;
-import com.stumbleupon.async.Deferred;
-import com.stumbleupon.async.DeferredGroupException;
-
-import org.hbase.async.AtomicIncrementRequest;
-import org.hbase.async.BinaryComparator;
-import org.hbase.async.BinaryPrefixComparator;
-import org.hbase.async.BitComparator;
-import org.hbase.async.Bytes;
-import org.hbase.async.ColumnPaginationFilter;
-import org.hbase.async.ColumnPrefixFilter;
-import org.hbase.async.ColumnRangeFilter;
-import org.hbase.async.CompareFilter.CompareOp;
-import org.hbase.async.DeleteRequest;
-import org.hbase.async.DependentColumnFilter;
-import org.hbase.async.FamilyFilter;
-import org.hbase.async.FilterList;
-import org.hbase.async.FirstKeyOnlyFilter;
-import org.hbase.async.FuzzyRowFilter;
-import org.hbase.async.GetRequest;
-import org.hbase.async.HBaseClient;
-import org.hbase.async.KeyRegexpFilter;
-import org.hbase.async.KeyValue;
-import org.hbase.async.NoSuchColumnFamilyException;
-import org.hbase.async.PutRequest;
-import org.hbase.async.QualifierFilter;
-import org.hbase.async.RegexStringComparator;
-import org.hbase.async.RowFilter;
-import org.hbase.async.ScanFilter;
-import org.hbase.async.Scanner;
-import org.hbase.async.SubstringComparator;
-import org.hbase.async.TableNotFoundException;
-import org.hbase.async.TimestampsFilter;
-import org.hbase.async.ValueFilter;
-import org.hbase.async.Common;
+import static org.junit.Assert.*;
 
 /**
  * Basic integration and regression tests for asynchbase.
@@ -127,6 +98,7 @@ final public class TestIntegration {
   private static String family;
   private static String[] args;
   private HBaseClient client;
+  private GetRequest[] gets;
 
   public static void main(final String[] args) throws Exception {
     preFlightTest(args);
@@ -626,6 +598,84 @@ final public class TestIntegration {
     }
   }
 
+  /** Lots of buffered multi-column counter increments from multiple threads. */
+  @Test
+  public void bufferedMultiColumnIncrementStressTest() throws Exception {
+    client.setFlushInterval(FAST_FLUSH);
+    final byte[] table = TestIntegration.table.getBytes();
+    final byte[] key1 = "cnt1".getBytes();  // Spread the increments..
+    final byte[] key2 = "cnt2".getBytes();  // .. over these two counters.
+    final byte[] family = TestIntegration.family.getBytes();
+    final byte[][] quals = { {'p'}, {'q'} };
+    final Collection<Deferred<Object>> dels =  new ArrayList<Deferred<Object>>();
+    dels.add(client.delete(new DeleteRequest(table, key1, family, quals[0])));
+    dels.add(client.delete(new DeleteRequest(table, key1, family, quals[1])));
+    dels.add(client.delete(new DeleteRequest(table, key2, family, quals[0])));
+    dels.add(client.delete(new DeleteRequest(table, key2, family, quals[1])));
+    Deferred.group(dels).join();
+
+    final int nthreads = Runtime.getRuntime().availableProcessors() * 2;
+    // The magic number comes from the limit on callbacks that Deferred
+    // imposes.  We spread increments over two counters, hence the x 2.
+    final int incr_per_thread = 8192 / nthreads * 2;
+    final boolean[] successes = new boolean[nthreads];
+
+    final class IncrementThread extends Thread {
+      private final int num;
+      public IncrementThread(final int num) {
+        super("IncrementThread-" + num);
+        this.num = num;
+      }
+      public void run() {
+        try {
+          doIncrements();
+          successes[num] = true;
+        } catch (Throwable e) {
+          successes[num] = false;
+          LOG.error("Uncaught exception", e);
+        }
+      }
+      private void doIncrements() {
+        for (int i = 0; i < incr_per_thread; i++) {
+          final byte[] key = i % 2 == 0 ? key1 : key2;
+          bufferMultiColumnIncrement(table, key, family, quals);
+        }
+      }
+    }
+
+    final IncrementThread[] threads = new IncrementThread[nthreads];
+    for (int i = 0; i < nthreads; i++) {
+      threads[i] = new IncrementThread(i);
+    }
+    LOG.info("Starting to generate multi-column increments");
+    for (int i = 0; i < nthreads; i++) {
+      threads[i].start();
+    }
+    for (int i = 0; i < nthreads; i++) {
+      threads[i].join();
+    }
+
+    LOG.info("Flushing all buffered multi-column increments.");
+    client.flush().joinUninterruptibly();
+    LOG.info("Done flushing all buffered multi-column increments.");
+
+    // Check that we the counters have the expected value.
+    final GetRequest[] gets = { mkGet(table, key1, family, quals[0]),
+        mkGet(table, key1, family, quals[1]),
+        mkGet(table, key2, family, quals[0]),
+        mkGet(table, key2, family, quals[1]) };
+    for (final GetRequest get : gets) {
+      final ArrayList<KeyValue> kvs = client.get(get).join();
+      assertSizeIs(1, kvs);
+      assertEquals(incr_per_thread * nthreads / 2,
+                   Bytes.getLong(kvs.get(0).value()));
+    }
+
+    for (int i = 0; i < nthreads; i++) {
+      assertEquals(true, successes[i]);  // Make sure no exception escaped.
+    }
+  }
+
   /** Increment coalescing with values too large to be coalesced. */
   @Test
   public void incrementCoalescingWithAmountsTooBig() throws Exception {
@@ -651,6 +701,41 @@ final public class TestIntegration {
     }).join();
     assertSizeIs(1, kvs);
     assertEquals(big + big, Bytes.getLong(kvs.get(0).value()));
+    // Check we sent the right number of RPCs.
+    assertEquals(2, client.stats().atomicIncrements());
+  }
+
+  /** Multi-column increment coalescing with values too large to be coalesced. */
+  @Test
+  public void multiColumnIncrementCoalescingWithAmountsTooBig() throws Exception {
+    client.setFlushInterval(SLOW_FLUSH);
+    final byte[] table = TestIntegration.table.getBytes();
+    final byte[] key = "cnt".getBytes();
+    final byte[] family = TestIntegration.family.getBytes();
+    final byte[][] quals = { {'p'}, {'q'} };
+
+    final Collection<Deferred<Object>> dels =  new ArrayList<Deferred<Object>>();
+    dels.add(client.delete(new DeleteRequest(table, key, family, quals[0])));
+    dels.add(client.delete(new DeleteRequest(table, key, family, quals[1])));
+    Deferred.group(dels).join();
+
+    final long big = 1L << 48;  // Too big to be coalesced.
+    final ArrayList<KeyValue> kvs = Deferred.group(
+            bufferMultiColumnIncrement(table, key, family, quals, new long[] { big, big }),
+            bufferMultiColumnIncrement(table, key, family, quals, new long[] { big, big })
+    ).addCallbackDeferring(new Callback<Deferred<ArrayList<KeyValue>>,
+            ArrayList<Map<byte[], Long>>>() {
+
+      public Deferred<ArrayList<KeyValue>> call(final ArrayList<Map<byte[], Long>> incs) {
+        final GetRequest get = new GetRequest(table, key)
+                .family(family).qualifiers(quals);
+        return client.get(get);
+      }
+    }).join();
+    assertSizeIs(2, kvs);
+    assertEquals(big + big, Bytes.getLong(kvs.get(0).value()));
+    assertEquals(big + big, Bytes.getLong(kvs.get(1).value()));
+
     // Check we sent the right number of RPCs.
     assertEquals(2, client.stats().atomicIncrements());
   }
@@ -683,6 +768,38 @@ final public class TestIntegration {
     assertEquals(2, client.stats().atomicIncrements());
   }
 
+  /** Multi-column increment coalescing with large values that overflow. */
+  @Test
+  public void multiColumnIncrementCoalescingWithOverflowingAmounts() throws Exception {
+    client.setFlushInterval(SLOW_FLUSH);
+    final byte[] table = TestIntegration.table.getBytes();
+    final byte[] key = "cnt".getBytes();
+    final byte[] family = TestIntegration.family.getBytes();
+    final byte[][] quals = { {'p'}, {'q'} };
+
+    final Collection<Deferred<Object>> dels =  new ArrayList<Deferred<Object>>();
+    dels.add(client.delete(new DeleteRequest(table, key, family, quals[0])));
+    dels.add(client.delete(new DeleteRequest(table, key, family, quals[1])));
+    Deferred.group(dels).join();
+
+    final long big = 1L << 47;
+    // First two RPCs can be coalesced.
+    bufferMultiColumnIncrement(table, key, family, quals, new long[] { big, big });
+    bufferMultiColumnIncrement(table, key, family, quals, new long[] { 1, 1 });
+    // This one would cause an overflow, so will be sent as a separate RPC.
+    // Overflow would happen because the max value is (1L << 48) - 1.
+    bufferMultiColumnIncrement(table, key, family, quals, new long[] { big, big });
+    client.flush().joinUninterruptibly();
+    final GetRequest get = new GetRequest(table, key)
+      .family(family).qualifiers(quals);
+    final ArrayList<KeyValue> kvs = client.get(get).join();
+    assertSizeIs(2, kvs);
+    assertEquals(big + 1 + big, Bytes.getLong(kvs.get(0).value()));
+    assertEquals(big + 1 + big, Bytes.getLong(kvs.get(1).value()));
+    // Check we sent the right number of RPCs.
+    assertEquals(2, client.stats().atomicIncrements());
+  }
+
   /** Increment coalescing with negative values and underflows. */
   @Test
   public void incrementCoalescingWithUnderflowingAmounts() throws Exception {
@@ -707,6 +824,38 @@ final public class TestIntegration {
     final ArrayList<KeyValue> kvs = client.get(get).join();
     assertSizeIs(1, kvs);
     assertEquals(big - 1 + big, Bytes.getLong(kvs.get(0).value()));
+    // Check we sent the right number of RPCs.
+    assertEquals(2, client.stats().atomicIncrements());
+  }
+
+  /** Multi-column increment coalescing with negative values and underflows. */
+  @Test
+  public void multiColumnIncrementCoalescingWithUnderflowingAmounts() throws Exception {
+    client.setFlushInterval(SLOW_FLUSH);
+    final byte[] table = TestIntegration.table.getBytes();
+    final byte[] key = "cnt".getBytes();
+    final byte[] family = TestIntegration.family.getBytes();
+    final byte[][] quals = { {'p'}, {'q'} };
+
+    final Collection<Deferred<Object>> dels =  new ArrayList<Deferred<Object>>();
+    dels.add(client.delete(new DeleteRequest(table, key, family, quals[0])));
+    dels.add(client.delete(new DeleteRequest(table, key, family, quals[1])));
+    Deferred.group(dels).join();
+
+    final long big = -1L << 47;
+    // First two RPCs can be coalesced.
+    bufferMultiColumnIncrement(table, key, family, quals, new long[] { big, big });
+    bufferMultiColumnIncrement(table, key, family, quals, new long[] { -1, -1 });
+    // This one would cause an underflow, so will be sent as a separate RPC.
+    // Overflow would happen because the max value is -1L << 48.
+    bufferMultiColumnIncrement(table, key, family, quals, new long[] { big, big });
+    client.flush().joinUninterruptibly();
+    final GetRequest get = new GetRequest(table, key)
+      .family(family).qualifiers(quals);
+    final ArrayList<KeyValue> kvs = client.get(get).join();
+    assertSizeIs(2, kvs);
+    assertEquals(big - 1 + big, Bytes.getLong(kvs.get(0).value()));
+    assertEquals(big - 1 + big, Bytes.getLong(kvs.get(1).value()));
     // Check we sent the right number of RPCs.
     assertEquals(2, client.stats().atomicIncrements());
   }
@@ -744,6 +893,46 @@ final public class TestIntegration {
     assertEquals(2, client.stats().atomicIncrements());
   }
 
+  /** Multi-column increment coalescing where the coalesced sum ends up being zero. */
+  @Test
+  public void multiColumnIncrementCoalescingWithZeroSumAmount() throws Exception {
+    client.setFlushInterval(SLOW_FLUSH);
+    final byte[] table = TestIntegration.table.getBytes();
+    final byte[] key = "cnt".getBytes();
+    final byte[] family = TestIntegration.family.getBytes();
+    final byte[][] quals = { {'p'}, {'q'} };
+
+    final Collection<Deferred<Object>> dels =  new ArrayList<Deferred<Object>>();
+    dels.add(client.delete(new DeleteRequest(table, key, family, quals[0])));
+    dels.add(client.delete(new DeleteRequest(table, key, family, quals[1])));
+    Deferred.group(dels).join();
+
+    // HBase 0.98 and up do not create a KV on atomic increment when the
+    // increment amount is 0.  So let's first send an increment of some
+    // arbitrary value, and then ensure that this value hasn't changed.
+    Map<byte[], Long> inits = client.atomicIncrements(new MultiColumnAtomicIncrementRequest(table, key,
+            family, quals, new long[] {42,42})).join();
+    for(Map.Entry<byte[], Long> entry : inits.entrySet()) {
+      assertEquals(42, entry.getValue().longValue());
+    }
+
+    bufferMultiColumnIncrement(table, key, family, quals, new long[] { 1, 1 });
+    bufferMultiColumnIncrement(table, key, family, quals, new long[] { 2, 2 });
+    bufferMultiColumnIncrement(table, key, family, quals, new long[] { -3, -3 });
+
+    client.flush().joinUninterruptibly();
+    final GetRequest get = new GetRequest(table, key)
+      .family(family).qualifiers(quals);
+    final ArrayList<KeyValue> kvs = client.get(get).join();
+    assertSizeIs(2, kvs);
+    assertEquals(42, Bytes.getLong(kvs.get(0).value()));
+    assertEquals(42, Bytes.getLong(kvs.get(1).value()));
+    // The sum was 0, but must have sent the increment anyway.
+    // So in total we should have sent two increments, the initial one,
+    // that sets the value to 42, and the one incrementing by zero.
+    assertEquals(2, client.stats().atomicIncrements());
+  }
+
   /** Helper method to create an atomic increment request.  */
   private Deferred<Long> bufferIncrement(final byte[] table,
                                          final byte[] key, final byte[] family,
@@ -752,6 +941,23 @@ final public class TestIntegration {
       client.bufferAtomicIncrement(new AtomicIncrementRequest(table, key,
                                                               family, qual,
                                                               value));
+  }
+
+  /** Helper method to create an atomic multi-column increment request.  */
+  private Deferred<Map<byte[], Long>> bufferMultiColumnIncrement(final byte[] table,
+                                                                 final byte[] key, final byte[] family,
+                                                                 final byte[][] quals) {
+    return
+      client.bufferMultiColumnAtomicIncrement(new MultiColumnAtomicIncrementRequest(table, key,
+          family, quals));
+  }
+
+  private Deferred<Map<byte[], Long>> bufferMultiColumnIncrement(final byte[] table,
+                                                                 final byte[] key, final byte[] family,
+                                                                 final byte[][] quals, final long[] amounts) {
+    return
+      client.bufferMultiColumnAtomicIncrement(new MultiColumnAtomicIncrementRequest(table, key,
+          family, quals, amounts));
   }
 
   /** Helper method to create a get request.  */

--- a/test/TestIntegration.java
+++ b/test/TestIntegration.java
@@ -27,11 +27,6 @@
 package org.hbase.async;
 
 import java.lang.Exception;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
-import java.lang.reflect.Method;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.InputStream;
@@ -55,11 +50,7 @@ import org.junit.runner.Result;
 import org.junit.runner.notification.Failure;
 import org.junit.runner.notification.RunListener;
 import org.powermock.reflect.Whitebox;
-import org.slf4j.Logger;
 
-import java.io.*;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Map;
 
 import static org.junit.Assert.*;
@@ -331,7 +322,7 @@ final public class TestIntegration {
     final PutRequest put2 = new PutRequest(table, "s2", family, "q", "v2");
     final PutRequest put3 = new PutRequest(table, "s3", family, "q", "v3");
     Deferred.group(client.put(put1), client.put(put2),
-                   client.put(put3)).join();
+        client.put(put3)).join();
     // Scan the same 3 rows created above twice.
     for (int i = 0; i < 2; i++) {
       LOG.info("------------ iteration #" + i);
@@ -409,7 +400,7 @@ final public class TestIntegration {
                    client.put(put3)).join();
     final Scanner scanner = client.newScanner(table);
     scanner.setFamily(family);
-    scanner.setQualifiers(new byte[][] { { 'a' }, { 'c' } });
+    scanner.setQualifiers(new byte[][]{{'a'}, {'c'}});
     final ArrayList<ArrayList<KeyValue>> rows = scanner.nextRows(2).join();
     scanner.close().join();
     assertSizeIs(1, rows);
@@ -724,11 +715,11 @@ final public class TestIntegration {
             bufferMultiColumnIncrement(table, key, family, quals, new long[] { big, big }),
             bufferMultiColumnIncrement(table, key, family, quals, new long[] { big, big })
     ).addCallbackDeferring(new Callback<Deferred<ArrayList<KeyValue>>,
-            ArrayList<Map<byte[], Long>>>() {
+        ArrayList<Map<byte[], Long>>>() {
 
       public Deferred<ArrayList<KeyValue>> call(final ArrayList<Map<byte[], Long>> incs) {
         final GetRequest get = new GetRequest(table, key)
-                .family(family).qualifiers(quals);
+            .family(family).qualifiers(quals);
         return client.get(get);
       }
     }).join();
@@ -910,15 +901,15 @@ final public class TestIntegration {
     // HBase 0.98 and up do not create a KV on atomic increment when the
     // increment amount is 0.  So let's first send an increment of some
     // arbitrary value, and then ensure that this value hasn't changed.
-    Map<byte[], Long> inits = client.atomicIncrements(new MultiColumnAtomicIncrementRequest(table, key,
-            family, quals, new long[] {42,42})).join();
+    Map<byte[], Long> inits = client.atomicIncrement(new MultiColumnAtomicIncrementRequest(table, key,
+        family, quals, new long[]{42, 42})).join();
     for(Map.Entry<byte[], Long> entry : inits.entrySet()) {
       assertEquals(42, entry.getValue().longValue());
     }
 
-    bufferMultiColumnIncrement(table, key, family, quals, new long[] { 1, 1 });
+    bufferMultiColumnIncrement(table, key, family, quals, new long[]{1, 1});
     bufferMultiColumnIncrement(table, key, family, quals, new long[] { 2, 2 });
-    bufferMultiColumnIncrement(table, key, family, quals, new long[] { -3, -3 });
+    bufferMultiColumnIncrement(table, key, family, quals, new long[]{-3, -3});
 
     client.flush().joinUninterruptibly();
     final GetRequest get = new GetRequest(table, key)


### PR DESCRIPTION
I would like to propose a new API to allow multiple columns in the atomic increment operation.  The atomic increment operation seems to require a row lock on the server-side so it is more efficient to do multiple increments at once.  It also reduces the number of RPC calls especially for table with a lot of columns. 

The proposed implementation has been tested in our environment and saw nice improvement on performance.  For example, with a table of 50 columns, I observed gain of 7~10X throughput.
