### PR TITLE
Make RegionOpeningException subclass of NSRE

### DIFF
--- a/src/RegionOpeningException.java
+++ b/src/RegionOpeningException.java
@@ -31,37 +31,18 @@ package org.hbase.async;
  * opened or altered.
  * @since 1.7
  */
-public final class RegionOpeningException extends RecoverableException
-  implements HasFailedRpcException {
-  
+public final class RegionOpeningException extends NotServingRegionException {
+
   static final String REMOTE_CLASS =
       "org.apache.hadoop.hbase.exceptions.RegionOpeningException";
-  
-  final HBaseRpc failed_rpc;
-  
+
   /**
    * Constructor.
    * @param msg The message of the exception, potentially with a stack trace.
    * @param failed_rpc The RPC that caused this exception, if known, or null.
    */
   RegionOpeningException(final String msg, final HBaseRpc failed_rpc) {
-    super(msg);
-    this.failed_rpc = failed_rpc;
-  }
-
-  @Override
-  public String getMessage() {
-    // In many cases this exception never makes it to the outside world, thus
-    // its toString / getMessage methods are never called.  When it's called,
-    // it's typically called only once.  So it makes sense to lazily generate
-    // the message instead of always concatenating the toString representation
-    // of the RPC, which is easily large because it tends to contain long byte
-    // arrays.
-    return super.getMessage() + "\nCaused by RPC: " + failed_rpc;
-  }
-
-  public HBaseRpc getFailedRpc() {
-    return failed_rpc;
+    super(msg, failed_rpc);
   }
 
   @Override
@@ -73,5 +54,5 @@ public final class RegionOpeningException extends RecoverableException
     return new RegionOpeningException(msg.toString(), rpc);
   }
 
-  private static final long serialVersionUID = 3535495091647558710L;
+  private static final long serialVersionUID = 3886029827039374556L;
 }

--- a/test/TestRegionClientDecode.java
+++ b/test/TestRegionClientDecode.java
@@ -412,11 +412,11 @@ public class TestRegionClientDecode extends BaseTestRegionClient {
     assertNull(region_client.decode(ctx, chan, buffer, VOID));
 
     assertEquals(0, rpcs_inflight.size());
-    verify(hbase_client, never()).handleNSRE(any(HBaseRpc.class), 
+    verify(hbase_client, times(1)).handleNSRE(any(HBaseRpc.class), 
         any(byte[].class), any(RecoverableException.class));
     assertEquals(1, timer.tasks.size());
     assertEquals(60000, (long)timer.tasks.get(0).getValue());
-    verify(timer.timeouts.get(0), times(1)).cancel();
+    verify(timer.timeouts.get(0), never()).cancel();
   }
   
   @Test


### PR DESCRIPTION
I just noticed #117 is still not fixed in master. `RegionOpeningException` should be a subclass of NSRE.

See:
- 51fbf24
- 41df659
- https://github.com/apache/hbase/blob/rel/1.2.0/hbase-client/src/main/java/org/apache/hadoop/hbase/exceptions/RegionOpeningException.java#L33