### PR TITLE
Add three subclasses of NotServingRegionException to allow retries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,8 @@ asynchbase_SOURCES := \
 	src/RegionOfflineException.java	\
 	src/RegionMovedException.java	\
 	src/RegionOpeningException.java	\
+	src/RegionServerAbortedException.java	\
+	src/RegionServerStoppedException.java	\
 	src/RemoteException.java	\
 	src/RpcTimedOutException.java	\
 	src/RowFilter.java	\
@@ -119,6 +121,7 @@ asynchbase_SOURCES := \
 	src/SecureRpcHelper.java	\
 	src/SecureRpcHelper94.java	\
 	src/SecureRpcHelper96.java	\
+	src/ServerNotRunningYetException.java	\
 	src/SingletonList.java	\
 	src/SubstringComparator.java	\
 	src/TableNotFoundException.java	\

--- a/src/RegionClient.java
+++ b/src/RegionClient.java
@@ -101,6 +101,12 @@ final class RegionClient extends ReplayingDecoder<VoidEnum> {
                                new RegionMovedException(null, null));
     REMOTE_EXCEPTION_TYPES.put(RegionOpeningException.REMOTE_CLASS,
                                new RegionOpeningException(null, null));
+    REMOTE_EXCEPTION_TYPES.put(RegionServerAbortedException.REMOTE_CLASS,
+                               new RegionServerAbortedException(null, null));
+    REMOTE_EXCEPTION_TYPES.put(RegionServerStoppedException.REMOTE_CLASS,
+                               new RegionServerStoppedException(null, null));
+    REMOTE_EXCEPTION_TYPES.put(ServerNotRunningYetException.REMOTE_CLASS,
+                               new ServerNotRunningYetException(null, null));
     REMOTE_EXCEPTION_TYPES.put(UnknownScannerException.REMOTE_CLASS,
                                new UnknownScannerException(null, null));
     REMOTE_EXCEPTION_TYPES.put(UnknownRowLockException.REMOTE_CLASS,

--- a/src/RegionServerAbortedException.java
+++ b/src/RegionServerAbortedException.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2015  The Async HBase Authors.  All rights reserved.
+ * This file is part of Async HBase.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   - Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *   - Neither the name of the StumbleUpon nor the names of its contributors
+ *     may be used to endorse or promote products derived from this software
+ *     without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hbase.async;
+
+/**
+ * Thrown by the region server when it is aborting.
+ * @since 1.7.2
+ */
+public final class RegionServerAbortedException extends NotServingRegionException {
+
+  static final String REMOTE_CLASS =
+      "org.apache.hadoop.hbase.regionserver.RegionServerAbortedException";
+
+  /**
+   * Constructor.
+   * @param msg The message of the exception, potentially with a stack trace.
+   * @param failed_rpc The RPC that caused this exception, if known, or null.
+   */
+  RegionServerAbortedException(final String msg, final HBaseRpc failed_rpc) {
+    super(msg, failed_rpc);
+  }
+
+  @Override
+  RegionServerAbortedException make(final Object msg, final HBaseRpc rpc) {
+    if (msg == this || msg instanceof RegionServerAbortedException) {
+      final RegionServerAbortedException e = (RegionServerAbortedException) msg;
+      return new RegionServerAbortedException(e.getMessage(), rpc);
+    }
+    return new RegionServerAbortedException(msg.toString(), rpc);
+  }
+
+  private static final long serialVersionUID = 5271730245586408289L;
+}

--- a/src/RegionServerStoppedException.java
+++ b/src/RegionServerStoppedException.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2015  The Async HBase Authors.  All rights reserved.
+ * This file is part of Async HBase.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   - Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *   - Neither the name of the StumbleUpon nor the names of its contributors
+ *     may be used to endorse or promote products derived from this software
+ *     without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hbase.async;
+
+/**
+ * Thrown by the region server when it is in shutting down state.
+ * @since 1.7.2
+ */
+public final class RegionServerStoppedException extends NotServingRegionException {
+
+  static final String REMOTE_CLASS =
+      "org.apache.hadoop.hbase.regionserver.RegionServerStoppedException";
+
+  /**
+   * Constructor.
+   * @param msg The message of the exception, potentially with a stack trace.
+   * @param failed_rpc The RPC that caused this exception, if known, or null.
+   */
+  RegionServerStoppedException(final String msg, final HBaseRpc failed_rpc) {
+    super(msg, failed_rpc);
+  }
+
+  @Override
+  RegionServerStoppedException make(final Object msg, final HBaseRpc rpc) {
+    if (msg == this || msg instanceof RegionServerStoppedException) {
+      final RegionServerStoppedException e = (RegionServerStoppedException) msg;
+      return new RegionServerStoppedException(e.getMessage(), rpc);
+    }
+    return new RegionServerStoppedException(msg.toString(), rpc);
+  }
+
+  private static final long serialVersionUID = 8471936396398620419L;
+}

--- a/src/ServerNotRunningYetException.java
+++ b/src/ServerNotRunningYetException.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2015  The Async HBase Authors.  All rights reserved.
+ * This file is part of Async HBase.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   - Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *   - Neither the name of the StumbleUpon nor the names of its contributors
+ *     may be used to endorse or promote products derived from this software
+ *     without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hbase.async;
+
+/**
+ * Thrown by the region server when it is not yet running.
+ * @since 1.7.2
+ */
+public final class ServerNotRunningYetException extends NotServingRegionException {
+
+  static final String REMOTE_CLASS =
+      "org.apache.hadoop.hbase.ipc.ServerNotRunningYetException";
+
+  /**
+   * Constructor.
+   * @param msg The message of the exception, potentially with a stack trace.
+   * @param failed_rpc The RPC that caused this exception, if known, or null.
+   */
+  ServerNotRunningYetException(final String msg, final HBaseRpc failed_rpc) {
+    super(msg, failed_rpc);
+  }
+
+  @Override
+  ServerNotRunningYetException make(final Object msg, final HBaseRpc rpc) {
+    if (msg == this || msg instanceof ServerNotRunningYetException) {
+      final ServerNotRunningYetException e = (ServerNotRunningYetException) msg;
+      return new ServerNotRunningYetException(e.getMessage(), rpc);
+    }
+    return new ServerNotRunningYetException(msg.toString(), rpc);
+  }
+
+  private static final long serialVersionUID = -5874735592785825342L;
+}


### PR DESCRIPTION
These are the exceptions that are known to be thrown during regionserver restart or abort.

- RegionServerAbortedException
- RegionServerStoppedException
- ServerNotRunningYetException

Asynchbase as of now isn't aware of these classes, and interprets them as non-recoverable RemoteExceptions. This pull request adds them as subclasses of NSREs, so that the clients can wait until the situation is resolved and retry.