### PR TITLE
Fix HBaseClient getting stuck after NSREs

### DIFF
--- a/src/GetRequest.java
+++ b/src/GetRequest.java
@@ -190,7 +190,9 @@ public final class GetRequest extends HBaseRpc
    * indicating whether or not the given table / key exists.
    */
   static HBaseRpc exists(final byte[] table, final byte[] key) {
-    return new GetRequest(0F, table, key);
+    final GetRequest rpc = new GetRequest(0F, table, key);
+    rpc.setProbe(true);
+    return rpc;
   }
 
   /**
@@ -205,6 +207,7 @@ public final class GetRequest extends HBaseRpc
                          final byte[] key, final byte[] family) {
     final GetRequest rpc = new GetRequest(0F, table, key);
     rpc.family(family);
+    rpc.setProbe(true);
     return rpc;
   }
 

--- a/src/HBaseRpc.java
+++ b/src/HBaseRpc.java
@@ -478,18 +478,32 @@ public abstract class HBaseRpc {
   }
 
   /**
-   * If true, this RPC should fail-fast as soon as we know we have a problem.
+   * If true, this RPC is a probe which checks if the destination region is
+   * online.
    */
-  boolean probe = false;
+  private boolean probe = false;
 
-  public boolean isProbe() {
+  boolean isProbe() {
     return probe;
   }
 
-  public void setProbe(boolean probe) {
+  void setProbe(boolean probe) {
     this.probe = probe;
   }
-  
+
+  /**
+   * Whether or not if this RPC is a probe that is suspended by an NSRE
+   */
+  private boolean suspended_probe = false;
+
+  boolean isSuspendedProbe() {
+    return suspended_probe;
+  }
+
+  void setSuspendedProbe(boolean suspended_probe) {
+    this.suspended_probe = suspended_probe;
+  }
+
   /**
    * Package private constructor for RPCs that aren't for any region.
    */


### PR DESCRIPTION
Related: #65

We also have the issue where Asynchbase gets stuck after region splits, merges, and relocations all of which involve a series of NotServingRegionExceptions. This has been a big pain point for us as we can't perform administrative tasks such as rolling restart, with confidence.

To reproduce:
- Table with many number of regions spread across multiple region servers
    - We tested with a table with 256 regions on a 10-node cluster
- Uniformly distributed access to all regions using Asynchbase at a fixed rate
- Repeatedly trigger actions that will cause NSRE
    - Merge the regions down to 32 regions
    - Split them back to 256 regions
    - Move regions across the servers (shuffle)
    - Rolling-restart region servers
- After some time, requests to certain regions hang

I digged into the problem (mostly examining `got_nsre` when that happens) and found a scenario in which case Asynchbase stops working.

1. Get(x)
    - regions_cache[x] => R1
    - Tries to reach R1 but NotServingRegionException
    - handleNSRE
2. handleNSRE(Get(x))
    - got_nsre[R1] = [Exists(x'), Get(x)]
    - More requests are concurrently piling up on the region
    - got_nsre[R1] = [Exists(x'), Get(x), Get(y), Get(z)]
    - sendRpcToRegion(Exists(x'))
3. Exists(x')
    - regions_cache[x] => R2 (invalidated and updated by another thread)
    - Unfortunately R2 also gives NSRE
4. handleNSRE(Exists(x'))
    - got_nsre[R2] = empty => [Exists(x''), Exists(x')]
    - ...
    - got_nsre[R2] = [Exists(x''), Exists(x'), Get(a), Get(b), Get(c)]
    - sendRpcToRegion(Exists(x''))
5. Exists(x'')
    - regions_cache[x] => R1 (updated again)
        - This time regions_cache points back to R1
    - But let's say the region has moved to another server by now,
      the region client for R1 or R2 will throw NSRE.
6. handleNSRE(Exists(x''))
    - got_nsre[R1] = [Exists(x'), Get(x), Get(y), Get(z), Exists(x'')]
    - Since got_nsre[R1][0] != Exists(x''), it returns without calling
      sendRpcToRegion(Exists(x')) ("This NSRE is already known and being handled.").
7. Client hangs with no RPCs in flight
    - got_nsre[R1] = [Exists(x'), Get(x), Get(y), Get(z), Exists(x'')]
    - got_nsre[R2] = [Exists(x''), Exists(x'), Get(a), Get(b), Get(c)]
8. Any further requests to R1 or R2 will cause handleNSRE that does not call
   sendRpcToRegion (step 6) and hang.

### A solution

1. Make sure we don't prematurely return from handleNSRE in step 6
2. Break cyclic RPC chain
    - Exists(x') -> ... -> Exists(x'') -> Exists(x') -> ...

So that the pending RPCs are processed in the following order:

- Exists(x')
    - Get(x)
    - Get(y)
    - Get(z)
    - Exists(x'')
        - Exists(x')
            - Dependent RPCs are already processed above
        - Exists(a)
        - Exists(b)
        - Exists(c)

### Result

I'm not sure if there are any other holes, but we have confirmed that the patch (along with #132 and #133) solves the issue. We performed a long-running stress test on a test cluster; while sustaining 80K GET/s + 20K PUT/s from 10 app servers using 2K threads, we repeatedly restarted the region servers one by one without a pause for 2 days, and we didn't run into the problem. Without the patch we used to have the issue after just a few restarts. The patched version is also resilient to region splits and merges.
