### PR TITLE
RegionClientPipeline # handleDisconnect doesnt handle ipv6

### DIFF
--- a/src/HBaseClient.java
+++ b/src/HBaseClient.java
@@ -28,6 +28,7 @@ package org.hbase.async;
 
 import java.io.IOException;
 import java.net.InetAddress;
+import java.net.Inet6Address;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.UnknownHostException;
@@ -3811,6 +3812,13 @@ public final class HBaseClient {
    * <p>
    * <strong>This method can block</strong> as there is no API for
    * asynchronous DNS resolution in the JDK.
+   *
+   * IPv4 / IPv6 handling:
+   *
+   * if (JVM is running with -Djava.net.preferIPv6Addresses=true &&
+   *   remote host has IPv6 address) -> return IPv6 address
+   * otherwise return first address that remote host has (probably v4).
+   *
    * @param host The hostname to resolve.
    * @return The IP address associated with the given hostname,
    * or {@code null} if the address couldn't be resolved.
@@ -3818,7 +3826,23 @@ public final class HBaseClient {
   private static String getIP(final String host) {
     final long start = System.nanoTime();
     try {
-      final String ip = InetAddress.getByName(host).getHostAddress();
+      boolean preferV6 = Boolean.valueOf(
+        System.getProperty("java.net.preferIPv6Addresses"));
+      final String ip;
+      if (preferV6) {
+        InetAddress ipv6 = null;
+        for (InetAddress ia : InetAddress.getAllByName(host))  {
+          if (ia instanceof Inet6Address) {
+            ipv6 = ia;
+            break;
+          }
+        }
+        ip = (ipv6 != null)? ipv6.getHostAddress() :
+          InetAddress.getByName(host).getHostAddress();
+      } else {
+        ip = InetAddress.getByName(host).getHostAddress();
+      }
+
       final long latency = System.nanoTime() - start;
       if (latency > 500000/*ns*/ && LOG.isDebugEnabled()) {
         LOG.debug("Resolved IP of `" + host + "' to "

--- a/src/HBaseClient.java
+++ b/src/HBaseClient.java
@@ -3830,7 +3830,10 @@ public final class HBaseClient {
         System.getProperty("java.net.preferIPv6Addresses"));
       final String ip;
       if (preferV6) {
+        LOG.debug("Trying to get IPv6 address for host: " + host);
         InetAddress ipv6 = null;
+        LOG.debug("All resolved IPs for host: " + host + " are: " +
+          Arrays.toString(InetAddress.getAllByName(host)));
         for (InetAddress ia : InetAddress.getAllByName(host))  {
           if (ia instanceof Inet6Address) {
             ipv6 = ia;
@@ -3840,8 +3843,11 @@ public final class HBaseClient {
         ip = (ipv6 != null)? ipv6.getHostAddress() :
           InetAddress.getByName(host).getHostAddress();
       } else {
+        LOG.debug("Trying to get IPv4 address for host: " + host);
         ip = InetAddress.getByName(host).getHostAddress();
       }
+      LOG.info("Resolved IP address for host: " + host + " is: " + ip);
+
 
       final long latency = System.nanoTime() - start;
       if (latency > 500000/*ns*/ && LOG.isDebugEnabled()) {

--- a/src/HBaseClient.java
+++ b/src/HBaseClient.java
@@ -3228,15 +3228,15 @@ public final class HBaseClient {
     }
 
     LOG.warn("Couldn't connect to the RegionServer @ " + hostport);
-    final int colon = hostport.indexOf(':', 1);
-    if (colon < 1) {
+    final int lastColon = hostport.lastIndexOf(':');
+    if (lastColon < 1) {
       LOG.error("WTF?  Should never happen!  No `:' found in " + hostport);
       return null;
     }
-    final String host = getIP(hostport.substring(0, colon));
+    final String host = getIP(hostport.substring(0, lastColon));
     int port;
     try {
-      port = parsePortNumber(hostport.substring(colon + 1,
+      port = parsePortNumber(hostport.substring(lastColon + 1,
                                                 hostport.length()));
     } catch (NumberFormatException e) {
       LOG.error("WTF?  Should never happen!  Bad port in " + hostport, e);


### PR DESCRIPTION
That causes error in the logs like:

2017-03-12 01:07:02.422 [AsyncHBase I/O Boss #1] ERROR async.HBaseClient - WTF?  Should never happen!  Bad port in <ipv6 host : port>
java.lang.NumberFormatException: For input string: <ipv6 host : port>
        at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
        at java.lang.Integer.parseInt(Integer.java:580)
        at java.lang.Integer.parseInt(Integer.java:615)
        at org.hbase.async.HBaseClient.parsePortNumber(HBaseClient.java:3834)
        at org.hbase.async.HBaseClient.slowSearchClientIP(HBaseClient.java:3226)
        at org.hbase.async.HBaseClient.access$2100(HBaseClient.java:190)
        at org.hbase.async.HBaseClient$RegionClientPipeline.handleDisconnect(HBaseClient.java:3145)
        at org.hbase.async.HBaseClient$RegionClientPipeline.sendDownstream(HBaseClient.java:3096)
        at org.jboss.netty.channel.Channels.close(Channels.java:812)
        at org.jboss.netty.channel.AbstractChannel.close(AbstractChannel.java:197)
        at org.jboss.netty.channel.ChannelFutureListener$2.operationComplete(ChannelFutureListener.java:52)
        at org.jboss.netty.channel.DefaultChannelFuture.notifyListener(DefaultChannelFuture.java:427)
        at org.jboss.netty.channel.DefaultChannelFuture.notifyListeners(DefaultChannelFuture.java:413)
        at org.jboss.netty.channel.DefaultChannelFuture.setFailure(DefaultChannelFuture.java:380)
        at org.jboss.netty.channel.socket.nio.NioClientBoss.processSelectedKeys(NioClientBoss.java:109)
        at org.jboss.netty.channel.socket.nio.NioClientBoss.process(NioClientBoss.java:79)
        at org.jboss.netty.channel.socket.nio.AbstractNioSelector.run(AbstractNioSelector.java:312)
        at org.jboss.netty.channel.socket.nio.NioClientBoss.run(NioClientBoss.java:42)
        at org.jboss.netty.util.ThreadRenamingRunnable.run(ThreadRenamingRunnable.java:108)