### PR TITLE
Issue #164 AsyncHBase compatibility with HBase 1.3.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,11 @@ asynchbase_PROTOS := \
 	protobuf/Tracing.proto	\
 	protobuf/ZooKeeper.proto	\
 	protobuf/HBase.proto	\
-
+        protobuf/ClusterId.proto \
+        protobuf/ClusterStatus.proto \
+        protobuf/FS.proto \
+        protobuf/MapReduce.proto \
+ 
 PROTOBUF_GEN_DIR = $(top_builddir)/src/org/hbase/async/generated
 
 BUILT_SOURCES := $(asynchbase_PROTOS:protobuf/%.proto=$(PROTOBUF_GEN_DIR)/%PB.java)

--- a/protobuf/Client.proto
+++ b/protobuf/Client.proto
@@ -28,6 +28,7 @@ import "HBase.proto";
 import "Filter.proto";
 import "Cell.proto";
 import "Comparator.proto";
+import "MapReduce.proto";
 
 /**
  * The protocol buffer version of Authorizations.
@@ -49,6 +50,14 @@ message CellVisibility {
 message Column {
   required bytes family = 1;
   repeated bytes qualifier = 2;
+}
+
+/**
+ * Consistency defines the expected consistency level for an operation.
+ */
+enum Consistency {
+  STRONG   = 0;
+  TIMELINE = 1;
 }
 
 /**
@@ -75,6 +84,9 @@ message Get {
   // If the row to get doesn't exist, return the
   // closest row before.
   optional bool closest_row_before = 11 [default = false];
+
+  optional Consistency consistency = 12 [default = STRONG];
+  repeated ColumnFamilyTimeRange cf_time_range = 13;
 }
 
 message Result {
@@ -92,6 +104,15 @@ message Result {
   // used for Get to check existence only. Not set if existence_only was not set to true
   //  in the query.
   optional bool exists = 3;
+
+  // Whether or not the results are coming from possibly stale data
+  optional bool stale = 4 [default = false];
+
+  // Whether or not the entire result could be returned. Results will be split when
+  // the RPC chunk size limit is reached. Partial results contain only a subset of the
+  // cells for a row and must be combined with a result containing the remaining cells
+  // to form a complete result
+  optional bool partial = 5 [default = false];
 }
 
 /**
@@ -233,7 +254,10 @@ message Scan {
   optional bool load_column_families_on_demand = 13; /* DO NOT add defaults to load_column_families_on_demand. */
   optional bool small = 14;
   optional bool reversed = 15 [default = false];
+  optional Consistency consistency = 16 [default = STRONG];
   optional uint32 caching = 17;
+  optional bool allow_partial_results = 18;
+  repeated ColumnFamilyTimeRange cf_time_range = 19;
 }
 
 /**
@@ -254,6 +278,10 @@ message ScanRequest {
   optional uint32 number_of_rows = 4;
   optional bool close_scanner = 5;
   optional uint64 next_call_seq = 6;
+  optional bool client_handles_partials = 7;
+  optional bool client_handles_heartbeats = 8;
+  optional bool track_scan_metrics = 9;
+  optional bool renew = 10 [default = false];
 }
 
 /**
@@ -269,6 +297,7 @@ message ScanResponse {
   // has 3, 3, 3 in it, then we know that on the client, we are to make
   // three Results each of three Cells each.
   repeated uint32 cells_per_result = 1;
+
   optional uint64 scanner_id = 2;
   optional bool more_results = 3;
   optional uint32 ttl = 4;
@@ -276,6 +305,32 @@ message ScanResponse {
   // This field is mutually exclusive with cells_per_result (since the Cells will
   // be inside the pb'd Result)
   repeated Result results = 5;
+  optional bool stale = 6;
+
+  // This field is filled in if we are doing cellblocks. In the event that a row
+  // could not fit all of its cells into a single RPC chunk, the results will be
+  // returned as partials, and reconstructed into a complete result on the client
+  // side. This field is a list of flags indicating whether or not the result
+  // that the cells belong to is a partial result. For example, if this field
+  // has false, false, true in it, then we know that on the client side, we need to
+  // make another RPC request since the last result was only a partial.
+  repeated bool partial_flag_per_result = 7;
+
+  // A server may choose to limit the number of results returned to the client for
+  // reasons such as the size in bytes or quantity of results accumulated. This field
+  // will true when more results exist in the current region.
+  optional bool more_results_in_region = 8;
+
+  // This field is filled in if the server is sending back a heartbeat message.
+  // Heartbeat messages are sent back to the client to prevent the scanner from
+  // timing out. Seeing a heartbeat message communicates to the Client that the
+  // server would have continued to scan had the time limit not been reached.
+  optional bool heartbeat_message = 9;
+
+  // This field is filled in if the client has requested that scan metrics be tracked.
+  // The metrics tracked here are sent back to the client to be tracked together with
+  // the existing client side metrics.
+  optional ScanMetrics scan_metrics = 10;
 }
 
 /**
@@ -338,6 +393,24 @@ message RegionAction {
   repeated Action action = 3;
 }
 
+/*
+* Statistics about the current load on the region
+*/
+message RegionLoadStats {
+  // Percent load on the memstore. Guaranteed to be positive, between 0 and 100.
+  optional int32 memstoreLoad = 1 [default = 0];
+  // Percent JVM heap occupancy. Guaranteed to be positive, between 0 and 100.
+  // We can move this to "ServerLoadStats" should we develop them.
+  optional int32 heapOccupancy = 2 [default = 0];
+  // Compaction pressure. Guaranteed to be positive, between 0 and 100.
+  optional int32 compactionPressure = 3 [default = 0];
+}
+
+message MultiRegionLoadStats{
+  repeated RegionSpecifier region = 1;
+  repeated RegionLoadStats stat = 2;
+}
+
 /**
  * Either a Result or an Exception NameBytesPair (keyed by
  * exception name whose value is the exception stringified)
@@ -351,6 +424,8 @@ message ResultOrException {
   optional NameBytesPair exception = 3;
   // result if this was a coprocessor service call
   optional CoprocessorServiceResult service_result = 4;
+  // current load on the region
+  optional RegionLoadStats loadStats = 5 [deprecated=true];
 }
 
 /**
@@ -379,25 +454,29 @@ message MultiResponse {
   repeated RegionActionResult regionActionResult = 1;
   // used for mutate to indicate processed only
   optional bool processed = 2;
+  optional MultiRegionLoadStats regionStatistics = 3;
 }
 
 
 service ClientService {
   rpc Get(GetRequest)
-    returns(GetResponse);
+  returns(GetResponse);
 
   rpc Mutate(MutateRequest)
-    returns(MutateResponse);
+  returns(MutateResponse);
 
   rpc Scan(ScanRequest)
-    returns(ScanResponse);
+  returns(ScanResponse);
 
   rpc BulkLoadHFile(BulkLoadHFileRequest)
-    returns(BulkLoadHFileResponse);
+  returns(BulkLoadHFileResponse);
 
   rpc ExecService(CoprocessorServiceRequest)
-    returns(CoprocessorServiceResponse);
+  returns(CoprocessorServiceResponse);
+
+  rpc ExecRegionServerService(CoprocessorServiceRequest)
+  returns(CoprocessorServiceResponse);
 
   rpc Multi(MultiRequest)
-    returns(MultiResponse);
+  returns(MultiResponse);
 }

--- a/protobuf/ClusterId.proto
+++ b/protobuf/ClusterId.proto
@@ -15,29 +15,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import "Client.proto";
+
+// This file contains protocol buffers that are shared throughout HBase
+
 option java_package = "org.hbase.async.generated";
-option java_outer_classname = "MultiRowMutationPB";
+option java_outer_classname = "ClusterIdPB";
 option java_generate_equals_and_hash = false;
-option java_generic_services = false;
 option optimize_for = LITE_RUNTIME;
 
-message MultiRowMutationProcessorRequest{
-}
-
-message MultiRowMutationProcessorResponse{
-}
-
-message MutateRowsRequest {
-    repeated MutationProto mutation_request = 1;
-    optional uint64 nonce_group = 2;
-    optional uint64 nonce = 3;
-}
-
-message MutateRowsResponse {
-}
-
-service MultiRowMutationService {
-    rpc MutateRows(MutateRowsRequest)
-    returns(MutateRowsResponse);
+/**
+ * Content of the '/hbase/hbaseid', cluster id, znode.
+ * Also cluster of the ${HBASE_ROOTDIR}/hbase.id file.
+ */
+message ClusterId {
+  // This is the cluster id, a uuid as a String
+  required string cluster_id = 1;
 }

--- a/protobuf/ClusterStatus.proto
+++ b/protobuf/ClusterStatus.proto
@@ -1,0 +1,223 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file contains protocol buffers that are used for ClustStatus
+
+option java_package = "org.hbase.async.generated";
+option java_outer_classname = "ClusterStatusPB";
+option java_generate_equals_and_hash = false;
+option optimize_for = LITE_RUNTIME;
+
+import "HBase.proto";
+import "ClusterId.proto";
+import "FS.proto";
+
+message RegionState {
+  required RegionInfo region_info = 1;
+  required State state = 2;
+  optional uint64 stamp = 3;
+  enum State {
+    OFFLINE = 0;       // region is in an offline state
+    PENDING_OPEN = 1;  // sent rpc to server to open but has not begun
+    OPENING = 2;       // server has begun to open but not yet done
+    OPEN = 3;          // server opened region and updated meta
+    PENDING_CLOSE = 4; // sent rpc to server to close but has not begun
+    CLOSING = 5;       // server has begun to close but not yet done
+    CLOSED = 6;        // server closed region and updated meta
+    SPLITTING = 7;     // server started split of a region
+    SPLIT = 8;         // server completed split of a region
+    FAILED_OPEN = 9;   // failed to open, and won't retry any more
+    FAILED_CLOSE = 10; // failed to close, and won't retry any more
+    MERGING = 11;      // server started merge a region
+    MERGED = 12;       // server completed merge of a region
+    SPLITTING_NEW = 13;  // new region to be created when RS splits a parent
+                       // region but hasn't be created yet, or master doesn't
+                       // know it's already created
+    MERGING_NEW = 14;  // new region to be created when RS merges two
+                       // daughter regions but hasn't be created yet, or
+                       // master doesn't know it's already created
+  }
+}
+
+message RegionInTransition {
+  required RegionSpecifier spec = 1;
+  required RegionState region_state = 2;
+}
+
+/**
+ * sequence Id of a store
+ */
+message StoreSequenceId {
+  required bytes family_name = 1;
+  required uint64 sequence_id = 2;
+}
+
+/**
+ * contains a sequence id of a region which should be the minimum of its store sequence ids and
+ * list of sequence ids of the region's stores
+ */
+message RegionStoreSequenceIds {
+  required uint64 last_flushed_sequence_id = 1;
+  repeated StoreSequenceId store_sequence_id = 2;
+}
+
+message RegionLoad {
+  /** the region specifier */
+  required RegionSpecifier region_specifier = 1;
+
+  /** the number of stores for the region */
+  optional uint32 stores = 2;
+
+  /** the number of storefiles for the region */
+  optional uint32 storefiles = 3;
+
+  /** the total size of the store files for the region, uncompressed, in MB */
+  optional uint32 store_uncompressed_size_MB = 4;
+
+  /** the current total size of the store files for the region, in MB */
+  optional uint32 storefile_size_MB = 5;
+
+  /** the current size of the memstore for the region, in MB */
+  optional uint32 memstore_size_MB = 6;
+
+  /**
+   * The current total size of root-level store file indexes for the region,
+   * in MB. The same as {@link #rootIndexSizeKB} but in MB.
+   */
+  optional uint32 storefile_index_size_MB = 7;
+
+  /** the current total read requests made to region */
+  optional uint64 read_requests_count = 8;
+
+  /** the current total write requests made to region */
+  optional uint64 write_requests_count = 9;
+
+  /** the total compacting key values in currently running compaction */
+  optional uint64 total_compacting_KVs = 10;
+
+  /** the completed count of key values in currently running compaction */
+  optional uint64 current_compacted_KVs = 11;
+
+   /** The current total size of root-level indexes for the region, in KB. */
+  optional uint32 root_index_size_KB = 12;
+
+  /** The total size of all index blocks, not just the root level, in KB. */
+  optional uint32 total_static_index_size_KB = 13;
+
+  /**
+   * The total size of all Bloom filter blocks, not just loaded into the
+   * block cache, in KB.
+   */
+  optional uint32 total_static_bloom_size_KB = 14;
+
+  /** the most recent sequence Id from cache flush */
+  optional uint64 complete_sequence_id = 15;
+
+  /** The current data locality for region in the regionserver */
+  optional float data_locality = 16;
+
+  optional uint64 last_major_compaction_ts = 17 [default = 0];
+
+  /** the most recent sequence Id of store from cache flush */
+  repeated StoreSequenceId store_complete_sequence_id = 18;
+}
+
+/* Server-level protobufs */
+
+message ReplicationLoadSink {
+  required uint64 ageOfLastAppliedOp = 1;
+  required uint64 timeStampsOfLastAppliedOp = 2;
+}
+
+message ReplicationLoadSource {
+  required string peerID = 1;
+  required uint64 ageOfLastShippedOp = 2;
+  required uint32 sizeOfLogQueue = 3;
+  required uint64 timeStampOfLastShippedOp = 4;
+  required uint64 replicationLag = 5;
+}
+
+message ServerLoad {
+  /** Number of requests since last report. */
+  optional uint64 number_of_requests = 1;
+
+  /** Total Number of requests from the start of the region server. */
+  optional uint64 total_number_of_requests = 2;
+
+  /** the amount of used heap, in MB. */
+  optional uint32 used_heap_MB = 3;
+
+  /** the maximum allowable size of the heap, in MB. */
+  optional uint32 max_heap_MB = 4;
+
+  /** Information on the load of individual regions. */
+  repeated RegionLoad region_loads = 5;
+
+  /**
+   * Regionserver-level coprocessors, e.g., WALObserver implementations.
+   * Region-level coprocessors, on the other hand, are stored inside RegionLoad
+   * objects.
+   */
+  repeated Coprocessor coprocessors = 6;
+
+  /**
+   * Time when incremental (non-total) counts began being calculated (e.g. number_of_requests)
+   * time is measured as the difference, measured in milliseconds, between the current time
+   * and midnight, January 1, 1970 UTC.
+   */
+  optional uint64 report_start_time = 7;
+
+  /**
+   * Time when report was generated.
+   * time is measured as the difference, measured in milliseconds, between the current time
+   * and midnight, January 1, 1970 UTC.
+   */
+  optional uint64 report_end_time = 8;
+
+  /**
+   * The port number that this region server is hosing an info server on.
+   */
+  optional uint32 info_server_port = 9;
+
+  /**
+   * The replicationLoadSource for the replication Source status of this region server.
+   */
+  repeated ReplicationLoadSource replLoadSource = 10;
+
+  /**
+   * The replicationLoadSink for the replication Sink status of this region server.
+   */
+  optional ReplicationLoadSink replLoadSink = 11;
+}
+
+message LiveServerInfo {
+  required ServerName server = 1;
+  required ServerLoad server_load = 2;
+}
+
+message ClusterStatus {
+  optional HBaseVersionFileContent hbase_version = 1;
+  repeated LiveServerInfo live_servers = 2;
+  repeated ServerName dead_servers = 3;
+  repeated RegionInTransition regions_in_transition = 4;
+  optional ClusterId cluster_id = 5;
+  repeated Coprocessor master_coprocessors = 6;
+  optional ServerName master = 7;
+  repeated ServerName backup_masters = 8;
+  optional bool balancer_on = 9;
+}

--- a/protobuf/Comparator.proto
+++ b/protobuf/Comparator.proto
@@ -39,6 +39,10 @@ message BinaryComparator {
   required ByteArrayComparable comparable = 1;
 }
 
+message LongComparator {
+  required ByteArrayComparable comparable = 1;
+}
+
 message BinaryPrefixComparator {
   required ByteArrayComparable comparable = 1;
 }
@@ -61,6 +65,7 @@ message RegexStringComparator {
   required string pattern = 1;
   required int32 pattern_flags = 2;
   required string charset = 3;
+  optional string engine = 4;
 }
 
 message SubstringComparator {

--- a/protobuf/FS.proto
+++ b/protobuf/FS.proto
@@ -15,29 +15,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import "Client.proto";
+
+// This file contains protocol buffers that are written into the filesystem
+
 option java_package = "org.hbase.async.generated";
-option java_outer_classname = "MultiRowMutationPB";
+option java_outer_classname = "FSPB";
 option java_generate_equals_and_hash = false;
-option java_generic_services = false;
 option optimize_for = LITE_RUNTIME;
 
-message MultiRowMutationProcessorRequest{
+/**
+ * The ${HBASE_ROOTDIR}/hbase.version file content
+ */
+message HBaseVersionFileContent {
+  required string version = 1;
 }
 
-message MultiRowMutationProcessorResponse{
+/**
+ * Reference file content used when we split an hfile under a region.
+ */
+message Reference {
+  required bytes splitkey = 1;
+  enum Range {
+    TOP = 0;
+    BOTTOM = 1;
+  }
+  required Range range = 2;
 }
 
-message MutateRowsRequest {
-    repeated MutationProto mutation_request = 1;
-    optional uint64 nonce_group = 2;
-    optional uint64 nonce = 3;
-}
-
-message MutateRowsResponse {
-}
-
-service MultiRowMutationService {
-    rpc MutateRows(MutateRowsRequest)
-    returns(MutateRowsResponse);
-}

--- a/protobuf/Filter.proto
+++ b/protobuf/Filter.proto
@@ -145,6 +145,7 @@ message SkipFilter {
 
 message TimestampsFilter {
   repeated int64 timestamps = 1 [packed=true];
+  optional bool can_hint = 2;
 }
 
 message ValueFilter {
@@ -155,4 +156,15 @@ message WhileMatchFilter {
   required Filter filter = 1;
 }
 message FilterAllFilter {
+}
+
+message RowRange {
+  optional bytes start_row = 1;
+  optional bool start_row_inclusive = 2;
+  optional bytes stop_row = 3;
+  optional bool stop_row_inclusive =4;
+}
+
+message MultiRowRangeFilter {
+  repeated RowRange row_range_list = 1;
 }

--- a/protobuf/HBase.proto
+++ b/protobuf/HBase.proto
@@ -64,6 +64,7 @@ message RegionInfo {
   optional bytes end_key = 4;
   optional bool offline = 5;
   optional bool split = 6;
+  optional int32 replica_id = 7 [default = 0];
 }
 
 /**
@@ -101,6 +102,12 @@ message RegionSpecifier {
 message TimeRange {
   optional uint64 from = 1;
   optional uint64 to = 2;
+}
+
+/* ColumnFamily Specific TimeRange */
+message ColumnFamilyTimeRange {
+  required bytes column_family = 1;
+  required TimeRange time_range = 2;
 }
 
 /* Comparison operators */
@@ -163,6 +170,7 @@ message SnapshotDescription {
   }
   optional Type type = 4 [default = FLUSH];
   optional int32 version = 5;
+  optional string owner = 6;
 }
 
 /**
@@ -176,6 +184,16 @@ message ProcedureDescription {
 }
 
 message EmptyMsg {
+}
+
+enum TimeUnit {
+  NANOSECONDS = 1;
+  MICROSECONDS = 2;
+  MILLISECONDS = 3;
+  SECONDS = 4;
+  MINUTES = 5;
+  HOURS = 6;
+  DAYS = 7;
 }
 
 message LongMsg {
@@ -200,9 +218,22 @@ message NamespaceDescriptor {
   repeated NameStringPair configuration = 2;
 }
 
+// Rpc client version info proto. Included in ConnectionHeader on connection setup
+message VersionInfo {
+  required string version = 1;
+  required string url = 2;
+  required string revision = 3;
+  required string user = 4;
+  required string date = 5;
+  required string src_checksum = 6;
+  optional uint32 version_major = 7;
+  optional uint32 version_minor = 8;
+}
+
 /**
  * Description of the region server info
  */
 message RegionServerInfo {
   optional int32 infoPort = 1;
+  optional VersionInfo version_info = 2;
 }

--- a/protobuf/MapReduce.proto
+++ b/protobuf/MapReduce.proto
@@ -15,29 +15,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import "Client.proto";
+
+ //This file includes protocol buffers used in MapReduce only.
+
 option java_package = "org.hbase.async.generated";
-option java_outer_classname = "MultiRowMutationPB";
+option java_outer_classname = "MapReducePB";
 option java_generate_equals_and_hash = false;
-option java_generic_services = false;
 option optimize_for = LITE_RUNTIME;
 
-message MultiRowMutationProcessorRequest{
+import "HBase.proto";
+
+message ScanMetrics {
+  repeated NameInt64Pair metrics = 1;
 }
 
-message MultiRowMutationProcessorResponse{
-}
-
-message MutateRowsRequest {
-    repeated MutationProto mutation_request = 1;
-    optional uint64 nonce_group = 2;
-    optional uint64 nonce = 3;
-}
-
-message MutateRowsResponse {
-}
-
-service MultiRowMutationService {
-    rpc MutateRows(MutateRowsRequest)
-    returns(MutateRowsResponse);
+message TableSnapshotRegionSplit {
+  repeated string locations = 2;
+  optional TableSchema table = 3;
+  optional RegionInfo region = 4;
 }

--- a/protobuf/RPC.proto
+++ b/protobuf/RPC.proto
@@ -86,6 +86,7 @@ message ConnectionHeader {
   // Compressor we will use if cell block is compressed.  Server will throw exception if not supported.
   // Class must implement hadoop's CompressionCodec Interface.  Can't compress if no codec.
   optional string cell_block_compressor_class = 4;
+  optional VersionInfo version_info = 5;
 }
 
 // Optional Cell block Message.  Included in client RequestHeader
@@ -119,9 +120,10 @@ message RequestHeader {
   optional bool request_param = 4;
   // If present, then an encoded data block follows.
   optional CellBlockMeta cell_block_meta = 5;
-  // 0 is NORMAL priority.  100 is HIGH.  If no priority, treat it as NORMAL.
+  // 0 is NORMAL priority.  200 is HIGH.  If no priority, treat it as NORMAL.
   // See HConstants.
   optional uint32 priority = 6;
+  optional uint32 timeout = 7;
 }
 
 message ResponseHeader {

--- a/protobuf/ZooKeeper.proto
+++ b/protobuf/ZooKeeper.proto
@@ -26,17 +26,22 @@ option java_generate_equals_and_hash = false;
 option optimize_for = LITE_RUNTIME;
 
 import "HBase.proto";
+import "ClusterStatus.proto";
 
 /**
  * Content of the meta-region-server znode.
  */
 message MetaRegionServer {
-  // The ServerName hosting the meta region currently.
+  // The ServerName hosting the meta region currently, or destination server,
+  // if meta region is in transition.
   required ServerName server = 1;
   // The major version of the rpc the server speaks.  This is used so that
   // clients connecting to the cluster can have prior knowledge of what version
   // to send to a RegionServer.  AsyncHBase will use this to detect versions.
   optional uint32 rpc_version = 2;
+
+  // State of the region transition. OPEN means fully operational 'hbase:meta'
+  optional RegionState.State state = 3;
 }
 
 /**
@@ -47,6 +52,7 @@ message Master {
   required ServerName master = 1;
   // Major RPC version so that clients can know what version the master can accept.
   optional uint32 rpc_version = 2;
+  optional uint32 info_port = 3;
 }
 
 /**
@@ -119,6 +125,9 @@ message ReplicationPeer {
   // clusterkey is the concatenation of the slave cluster's
   // hbase.zookeeper.quorum:hbase.zookeeper.property.clientPort:zookeeper.znode.parent
   required string clusterkey = 1;
+  optional string replicationEndpointImpl = 2;
+  repeated BytesBytesPair data = 3;
+  repeated NameStringPair configuration = 4;
 }
 
 /**
@@ -133,7 +142,7 @@ message ReplicationState {
 }
 
 /**
- * Used by replication. Holds the current position in an HLog file.
+ * Used by replication. Holds the current position in an WAL file.
  */
 message ReplicationHLogPosition {
   required int64 position = 1;
@@ -159,18 +168,8 @@ message TableLock {
 }
 
 /**
- * sequence Id of a store
+ * State of the switch.
  */
-message StoreSequenceId {
-  required bytes family_name = 1;
-  required uint64 sequence_id = 2;
-}
-
-/**
- * contains a sequence id of a region which should be the minimum of its store sequence ids and 
- * list sequence ids of the region's stores
- */
-message RegionStoreSequenceIds {
-  required uint64 last_flushed_sequence_id = 1;
-  repeated StoreSequenceId store_sequence_id = 2;
+message SwitchState {
+  optional bool enabled = 1;
 }


### PR DESCRIPTION
Following changes are made.
1. Client Protos upgraded from HBase 0.98 to 1.3
2. Makefiles modified for adding new files
3. Handling of 'more_results_in_region' bit in ScanResponse
If this bit is unset then new GetNextRowsRequest is not issued since the scanner will be already closed on server side and will result into exceptions on client side if the RPC is still made.
4. Added an integration test that scans across multiple regions, thus involving multiple open, close and getnextrows requests.