### PR TITLE
make the family mutable again

### DIFF
--- a/src/BatchableRpc.java
+++ b/src/BatchableRpc.java
@@ -45,7 +45,7 @@ abstract class BatchableRpc extends HBaseRpc
   // access them directly.
 
   /** Family affected by this RPC.  */
-  /*protected*/ final byte[] family;
+  /*protected*/ byte[] family;
 
   /** The timestamp to use for {@link KeyValue}s of this RPC.  */
   /*protected*/ final long timestamp;

--- a/src/GetRequest.java
+++ b/src/GetRequest.java
@@ -52,7 +52,6 @@ public final class GetRequest extends BatchableRpc
   private static final byte[] EXISTS =
     new byte[] { 'e', 'x', 'i', 's', 't', 's' };
 
-  private byte[] family;     // TODO(tsuna): Handle multiple families?
   private byte[][] qualifiers;
   private long lockid = RowLock.NO_LOCK;
   private boolean populate_blockcache = true;


### PR DESCRIPTION
fixes GetRequest mutator `family(String|byte[])`
removes masked family variable

see https://github.com/OpenTSDB/asynchbase/issues/174

@manolama can you take a look a this, it's a pretty serious bug if your code uses the mutable family on a get request