### PR TITLE
Add RegionTooBusyException to allow retries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,7 @@ asynchbase_SOURCES := \
 	src/RegionOpeningException.java	\
 	src/RegionServerAbortedException.java	\
 	src/RegionServerStoppedException.java	\
+	src/RegionTooBusyException.java \
 	src/RemoteException.java	\
 	src/RpcTimedOutException.java	\
 	src/RowFilter.java	\

--- a/src/RegionClient.java
+++ b/src/RegionClient.java
@@ -105,6 +105,8 @@ final class RegionClient extends ReplayingDecoder<VoidEnum> {
                                new RegionServerAbortedException(null, null));
     REMOTE_EXCEPTION_TYPES.put(RegionServerStoppedException.REMOTE_CLASS,
                                new RegionServerStoppedException(null, null));
+    REMOTE_EXCEPTION_TYPES.put(RegionTooBusyException.REMOTE_CLASS,
+                               new RegionTooBusyException(null, null));
     REMOTE_EXCEPTION_TYPES.put(ServerNotRunningYetException.REMOTE_CLASS,
                                new ServerNotRunningYetException(null, null));
     REMOTE_EXCEPTION_TYPES.put(UnknownScannerException.REMOTE_CLASS,

--- a/src/RegionTooBusyException.java
+++ b/src/RegionTooBusyException.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2015  The Async HBase Authors.  All rights reserved.
+ * This file is part of Async HBase.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   - Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *   - Neither the name of the StumbleUpon nor the names of its contributors
+ *     may be used to endorse or promote products derived from this software
+ *     without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hbase.async;
+
+/**
+ * Thrown by the region server if it will block and wait to serve a request.
+ * @since 1.7.2
+ */
+public final class RegionTooBusyException extends NotServingRegionException {
+
+  static final String REMOTE_CLASS =
+      "org.apache.hadoop.hbase.RegionTooBusyException";
+
+  /**
+   * Constructor.
+   * @param msg The message of the exception, potentially with a stack trace.
+   * @param failed_rpc The RPC that caused this exception, if known, or null.
+   */
+  RegionTooBusyException(final String msg, final HBaseRpc failed_rpc) {
+    super(msg, failed_rpc);
+  }
+
+  @Override
+  RegionTooBusyException make(final Object msg, final HBaseRpc rpc) {
+    if (msg == this || msg instanceof RegionTooBusyException) {
+      final RegionTooBusyException e = (RegionTooBusyException) msg;
+      return new RegionTooBusyException(e.getMessage(), rpc);
+    }
+    return new RegionTooBusyException(msg.toString(), rpc);
+  }
+
+  private static final long serialVersionUID = 314159265319912017L;
+}

--- a/test/TestRegionClientDecode.java
+++ b/test/TestRegionClientDecode.java
@@ -377,6 +377,11 @@ public class TestRegionClientDecode extends BaseTestRegionClient {
   }
 
   @Test
+  public void regionTooBusyException() throws Exception {
+    notServingRegionException("org.apache.hadoop.hbase.RegionTooBusyException");
+  }
+
+  @Test
   public void serverNotRunningYetException() throws Exception {
     notServingRegionException("org.apache.hadoop.hbase.ipc.ServerNotRunningYetException");
   }


### PR DESCRIPTION
RegionTooBusyException is thrown when region server will block and wait to serve a request. For example, the client wants to insert something into a region while the region is compacting. The client is expected to retry.

We encountered the same issue as https://github.com/OpenTSDB/opentsdb/issues/757 and https://github.com/OpenTSDB/opentsdb/issues/878. Finally, we found out that AsyncHBase should be able to distinguish the RegionTooBusyException. Then clients can retry for this.