### PR TITLE
Add a config flag (via file or JVM flag) called 'hbase.meta.scan' tha…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,7 @@ before_script:
   - make pom.xml
 script: export MAVEN_OPTS="-Xmx1024m" && mvn test --quiet
 jdk:
-  - oraclejdk7
-  - openjdk6
+  - openjdk7
   - oraclejdk8
 notifications:
     email: false

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright (C) 2010-2012  The Async HBase Authors.  All rights reserved.
+# Copyright (C) 2010-2017  The Async HBase Authors.  All rights reserved.
 # This file is part of Async HBase.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -39,7 +39,7 @@ proto_builddir := $(top_builddir)/protobuf
 spec_title := Asynchronous HBase Client
 spec_vendor := The Async HBase Authors
 # Semantic Versioning (see http://semver.org/).
-spec_version := 1.8.0-SNAPSHOT
+spec_version := 1.9.0-SNAPSHOT
 jar := $(top_builddir)/asynchbase-$(spec_version).jar
 
 asynchbase_PROTOS := \

--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,7 @@ asynchbase_SOURCES := \
 	src/RegionOpeningException.java	\
 	src/RegionServerAbortedException.java	\
 	src/RegionServerStoppedException.java	\
+	src/RegionTooBusyException.java \
 	src/RemoteException.java	\
 	src/RpcTimedOutException.java	\
 	src/RowFilter.java	\

--- a/src/BatchableRpc.java
+++ b/src/BatchableRpc.java
@@ -45,7 +45,7 @@ abstract class BatchableRpc extends HBaseRpc
   // access them directly.
 
   /** Family affected by this RPC.  */
-  /*protected*/ final byte[] family;
+  /*protected*/ byte[] family;
 
   /** The timestamp to use for {@link KeyValue}s of this RPC.  */
   /*protected*/ final long timestamp;

--- a/src/GetRequest.java
+++ b/src/GetRequest.java
@@ -52,7 +52,6 @@ public final class GetRequest extends BatchableRpc
   private static final byte[] EXISTS =
     new byte[] { 'e', 'x', 'i', 's', 't', 's' };
 
-  private byte[] family;     // TODO(tsuna): Handle multiple families?
   private byte[][] qualifiers;
   private long lockid = RowLock.NO_LOCK;
   private boolean populate_blockcache = true;

--- a/src/HBaseClient.java
+++ b/src/HBaseClient.java
@@ -67,6 +67,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.UnknownHostException;
+import java.nio.channels.ClosedChannelException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -3742,13 +3743,22 @@ public final class HBaseClient {
     @Override
     public void channelIdle(ChannelHandlerContext ctx, IdleStateEvent e)
             throws Exception {
-      if(e.getState() == IdleState.ALL_IDLE) {
+      if (e.getState() == IdleState.ALL_IDLE) {
         idle_connections_closed.increment();
         LOG.info("Closing idle connection to HBase region server: " 
             + e.getChannel());
         // RegionClientPipeline's disconnect method will handle cleaning up
         // any outstanding RPCs and removing the client from caches
-        e.getChannel().close();
+        try {
+          e.getChannel().close();
+        } catch (Exception ex) {
+          // This handler may be called after a channel has entered an odd state
+          // or already been closed. If it has been closed properly, then ignore
+          // the exception, otherwise throw it.
+          if (!(ex instanceof ClosedChannelException)) {
+            throw ex;
+          }
+        }
       }
     }
   }

--- a/src/HBaseClient.java
+++ b/src/HBaseClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2012  The Async HBase Authors.  All rights reserved.
+ * Copyright (C) 2010-2018  The Async HBase Authors.  All rights reserved.
  * This file is part of Async HBase.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -415,6 +415,9 @@ public final class HBaseClient {
   
   /** Default RPC timeout in milliseconds from the config */
   private final int rpc_timeout;
+
+  /** Whether or not we have to scan meta instead of making getClosestBeforeRow calls. */
+  private final boolean scan_meta;
   
   private boolean increment_buffer_durable = false;
   
@@ -549,6 +552,11 @@ public final class HBaseClient {
     if (config.properties.containsKey("hbase.increments.durable")) {
       increment_buffer_durable = config.getBoolean("hbase.increments.durable");
     }
+    if (config.hasProperty("hbase.meta.scan")) {
+      scan_meta = config.getBoolean("hbase.meta.scan");
+    } else {
+      scan_meta = Boolean.parseBoolean(System.getProperty("hbase.meta.scan", "false"));
+    }
   }
   
   /**
@@ -609,6 +617,11 @@ public final class HBaseClient {
     nsre_high_watermark = config.getShort("hbase.nsre.high_watermark");
     if (config.properties.containsKey("hbase.increments.durable")) {
       increment_buffer_durable = config.getBoolean("hbase.increments.durable");
+    }
+    if (config.hasProperty("hbase.meta.scan")) {
+      scan_meta = config.getBoolean("hbase.meta.scan");
+    } else {
+      scan_meta = Boolean.parseBoolean(System.getProperty("hbase.meta.scan", "false"));
     }
   }
   
@@ -2714,11 +2727,21 @@ public final class HBaseClient {
         Deferred<Object> d = null;
         try {
           if (return_location) {
-            d = client.getClosestRowBefore(meta_region, meta_name, meta_key, INFO)
+            if (scan_meta) {
+              d = scanMeta(client, meta_region, meta_name, meta_key, INFO)
                   .addCallback(meta_lookup_done_return_location);
-          } else{
-            d = client.getClosestRowBefore(meta_region, meta_name, meta_key, INFO)
+            } else {
+              d = client.getClosestRowBefore(meta_region, meta_name, meta_key, INFO)
+                  .addCallback(meta_lookup_done_return_location);
+            }
+          } else {
+            if (scan_meta) {
+              d = scanMeta(client, meta_region, meta_name, meta_key, INFO)
                   .addCallback(meta_lookup_done);
+            } else {
+              d = client.getClosestRowBefore(meta_region, meta_name, meta_key, INFO)
+                  .addCallback(meta_lookup_done);
+            }
           }
         } catch (RuntimeException e) {
           LOG.error("Unexpected exception while performing meta lookup", e);
@@ -2770,6 +2793,75 @@ public final class HBaseClient {
                     closest_before, return_location));
   }
 
+  /**
+   * Later versions of HBase dropped the old 
+   * {@link RegionClient#getClosestRowBefore(RegionInfo, byte[], byte[], byte[])}
+   * method and switched to performing reverse scans. This method will 
+   * handle the scanning returning either a meta row if found or an empty
+   * array if the row/table was not found.
+   * TODO - need to see what happens with split meta.
+   * 
+   * @param client The region client to open the scanner on.
+   * @param region The region we're scanning for.
+   * @param table The name of the table to scan for.
+   * @param row The row to scan for.
+   * @param family The family to scan on.
+   * @return A deferred resolving to an array list containing region
+   * info if successful or an empty array if the table/region doesn't
+   * exist. Or an exception if something goes pear shaped.
+   */
+  private Deferred<ArrayList<KeyValue>> scanMeta(final RegionClient client, 
+                                                 final RegionInfo region, 
+                                                 final byte[] table, 
+                                                 final byte[] row, 
+                                                 final byte[] family) {
+    final Scanner scanner = newScanner(table);
+    scanner.setReversed(true);
+    scanner.setMaxNumRows(1);
+    scanner.setStartKey(row);
+    scanner.setFamily(family);
+    scanner.setRegionName(region);
+    
+    final Deferred<ArrayList<KeyValue>> deferred = 
+        new Deferred<ArrayList<KeyValue>>();
+    
+    class ErrorCB implements Callback<Object, Exception> {
+      @Override
+      public Object call(final Exception ex) throws Exception {
+        scanner.close();
+        deferred.callback(ex);
+        return null;
+      }
+      @Override
+      public String toString() {
+        return "scanMeta.ErrorCB";
+      }
+    }
+    
+    class MetaScanCB implements Callback<Void, ArrayList<ArrayList<KeyValue>>> {
+      @Override
+      public Void call(final ArrayList<ArrayList<KeyValue>> rows)
+          throws Exception {
+        final ArrayList<KeyValue> row = (rows == null || rows.isEmpty()) 
+            ? new ArrayList<KeyValue>(0) : rows.get(0);
+        scanner.close();
+        deferred.callback(row);
+        return null;
+      }
+      @Override
+      public String toString() {
+        return "scanMeta.MetaScanCB";
+      }
+    }
+    
+    HBaseRpc open_request = scanner.getOpenRequestForReverseScan(row);
+    open_request.region = region;
+    open_request.getDeferred().addCallbackDeferring(scanner.opened_scanner)
+      .addCallbacks(new MetaScanCB(), new ErrorCB());
+    client.sendRpc(open_request);
+    return deferred;
+  }
+  
   /**
    * Callback executed when a lookup in META completes
    * and user wants RegionLocation.

--- a/src/HBaseRpc.java
+++ b/src/HBaseRpc.java
@@ -496,12 +496,20 @@ public abstract class HBaseRpc {
    */
   private boolean suspended_probe = false;
 
-  synchronized boolean isSuspendedProbe() {
-    return suspended_probe;
+  boolean isSuspendedProbe() {
+    // since the key doesn't change, we are safe to lock on it and we avoid 
+    // locking the entire object. TODO - still may be some issues with behavior.
+    synchronized(key) {
+      return suspended_probe;
+    }
   }
 
-  synchronized void setSuspendedProbe(boolean suspended_probe) {
-    this.suspended_probe = suspended_probe;
+  void setSuspendedProbe(boolean suspended_probe) {
+    // since the key doesn't change, we are safe to lock on it and we avoid 
+    // locking the entire object. TODO - still may be some issues with behavior.
+    synchronized(key) {
+      this.suspended_probe = suspended_probe;
+    }
   }
 
   /**

--- a/src/HBaseRpc.java
+++ b/src/HBaseRpc.java
@@ -494,7 +494,7 @@ public abstract class HBaseRpc {
   /**
    * Whether or not if this RPC is a probe that is suspended by an NSRE
    */
-  private boolean suspended_probe = false;
+  private volatile boolean suspended_probe = false;
 
   boolean isSuspendedProbe() {
     // since the key doesn't change, we are safe to lock on it and we avoid 

--- a/src/RegionClient.java
+++ b/src/RegionClient.java
@@ -105,6 +105,8 @@ final class RegionClient extends ReplayingDecoder<VoidEnum> {
                                new RegionServerAbortedException(null, null));
     REMOTE_EXCEPTION_TYPES.put(RegionServerStoppedException.REMOTE_CLASS,
                                new RegionServerStoppedException(null, null));
+    REMOTE_EXCEPTION_TYPES.put(RegionTooBusyException.REMOTE_CLASS,
+                               new RegionTooBusyException(null, null));
     REMOTE_EXCEPTION_TYPES.put(ServerNotRunningYetException.REMOTE_CLASS,
                                new ServerNotRunningYetException(null, null));
     REMOTE_EXCEPTION_TYPES.put(UnknownScannerException.REMOTE_CLASS,

--- a/src/RegionTooBusyException.java
+++ b/src/RegionTooBusyException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015  The Async HBase Authors.  All rights reserved.
+ * Copyright (C) 2018  The Async HBase Authors.  All rights reserved.
  * This file is part of Async HBase.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,7 +28,7 @@ package org.hbase.async;
 
 /**
  * Thrown by the region server if it will block and wait to serve a request.
- * @since 1.7.2
+ * @since 1.8.1
  */
 public final class RegionTooBusyException extends NotServingRegionException {
 

--- a/src/RegionTooBusyException.java
+++ b/src/RegionTooBusyException.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2015  The Async HBase Authors.  All rights reserved.
+ * This file is part of Async HBase.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   - Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *   - Neither the name of the StumbleUpon nor the names of its contributors
+ *     may be used to endorse or promote products derived from this software
+ *     without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hbase.async;
+
+/**
+ * Thrown by the region server if it will block and wait to serve a request.
+ * @since 1.7.2
+ */
+public final class RegionTooBusyException extends NotServingRegionException {
+
+  static final String REMOTE_CLASS =
+      "org.apache.hadoop.hbase.RegionTooBusyException";
+
+  /**
+   * Constructor.
+   * @param msg The message of the exception, potentially with a stack trace.
+   * @param failed_rpc The RPC that caused this exception, if known, or null.
+   */
+  RegionTooBusyException(final String msg, final HBaseRpc failed_rpc) {
+    super(msg, failed_rpc);
+  }
+
+  @Override
+  RegionTooBusyException make(final Object msg, final HBaseRpc rpc) {
+    if (msg == this || msg instanceof RegionTooBusyException) {
+      final RegionTooBusyException e = (RegionTooBusyException) msg;
+      return new RegionTooBusyException(e.getMessage(), rpc);
+    }
+    return new RegionTooBusyException(msg.toString(), rpc);
+  }
+
+  private static final long serialVersionUID = 314159265319912017L;
+}

--- a/src/Scanner.java
+++ b/src/Scanner.java
@@ -231,7 +231,7 @@ public final class Scanner {
   */
   public void setReversed(boolean reversed){
     checkScanningNotStarted();
-    is_reversed = true;
+    is_reversed = reversed;
   }
 
   /**

--- a/src/Scanner.java
+++ b/src/Scanner.java
@@ -766,7 +766,7 @@ public final class Scanner {
   /**
    * Callback to handle response from opening a scanner
    */
-  private final Callback<Deferred<ArrayList<ArrayList<KeyValue>>>, Object>
+   final Callback<Deferred<ArrayList<ArrayList<KeyValue>>>, Object>
     opened_scanner =
       new Callback<Deferred<ArrayList<ArrayList<KeyValue>>>, Object>() {
           public Deferred<ArrayList<ArrayList<KeyValue>>> call(final Object arg) {
@@ -806,7 +806,7 @@ public final class Scanner {
    * This returns an {@code ArrayList<ArrayList<KeyValue>>} (possibly inside a
    * deferred one).
    */
-  private final Callback<Object, Object> got_next_row =
+  final Callback<Object, Object> got_next_row =
     new Callback<Object, Object>() {
       public Object call(final Object response) {
         ArrayList<ArrayList<KeyValue>> rows = null;
@@ -841,7 +841,7 @@ public final class Scanner {
   /**
    * Creates a new errback to handle errors while trying to get more rows.
    */
-  private final Callback<Object, Object> nextRowErrback() {
+  final Callback<Object, Object> nextRowErrback() {
     return new Callback<Object, Object>() {
       public Object call(final Object error) {
         final RegionInfo old_region = region;  // Save before invalidate().
@@ -1481,7 +1481,7 @@ public final class Scanner {
    * RPC sent out to fetch the next rows from the RegionServer.
    */
   final class GetNextRowsRequest extends HBaseRpc {
-
+    
     @Override
     byte[] method(final byte server_version) {
       return (server_version >= RegionClient.SERVER_VERSION_095_OR_ABOVE

--- a/src/SecureRpcHelper.java
+++ b/src/SecureRpcHelper.java
@@ -231,7 +231,7 @@ public abstract class SecureRpcHelper {
     }
 
     try {
-      final byte[] payload = new byte[content.writerIndex()];
+      final byte[] payload = new byte[content.readableBytes()];
       content.readBytes(payload);
       final byte[] wrapped = sasl_client.wrap(payload, 0, payload.length);
       final ChannelBuffer ret = ChannelBuffers.wrappedBuffer(

--- a/test/TestRegionClientDecode.java
+++ b/test/TestRegionClientDecode.java
@@ -377,6 +377,11 @@ public class TestRegionClientDecode extends BaseTestRegionClient {
   }
 
   @Test
+  public void regionTooBusyException() throws Exception {
+    notServingRegionException("org.apache.hadoop.hbase.RegionTooBusyException");
+  }
+
+  @Test
   public void serverNotRunningYetException() throws Exception {
     notServingRegionException("org.apache.hadoop.hbase.ipc.ServerNotRunningYetException");
   }


### PR DESCRIPTION
…t should

be set when HBase 2.x is used. This will turn on reverse scanning for meta
information as opposed to the old way of calling getClosestRowBefore().
As part of this, some callbacks in the Scanner class are now package private
so we can re-use them in HBaseClient.java.
Fixes #150 Thanks @saintstack

TODO - need to see how this behaves with split meta.
TODO - I'd still like to auto-detect HBase 2.0 somehow.