### PR TITLE
Auto-detect HBase 2.0 based on getClosestRowOrBefore throwing an

### DIFF
--- a/src/RegionClient.java
+++ b/src/RegionClient.java
@@ -117,6 +117,8 @@ final class RegionClient extends ReplayingDecoder<VoidEnum> {
                                new VersionMismatchException(null, null));
     REMOTE_EXCEPTION_TYPES.put(CallQueueTooBigException.REMOTE_CLASS,
                                new CallQueueTooBigException(null, null));
+    REMOTE_EXCEPTION_TYPES.put(UnknownProtocolException.REMOTE_CLASS,
+                               new UnknownProtocolException(null, null));
   }
 
   /** We don't know the RPC protocol version of the server yet.  */

--- a/src/UnknownProtocolException.java
+++ b/src/UnknownProtocolException.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2018  The Async HBase Authors.  All rights reserved.
+ * This file is part of Async HBase.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   - Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *   - Neither the name of the StumbleUpon nor the names of its contributors
+ *     may be used to endorse or promote products derived from this software
+ *     without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hbase.async;
+
+/**
+ * Used by HBase 2.0 to indicate the server doesn't support 
+ * getClosestRowBefore any more (or other incorrect calls to HBase).
+ */
+public class UnknownProtocolException extends NonRecoverableException 
+  implements HasFailedRpcException {
+  
+  static final String REMOTE_CLASS =
+      "org.apache.hadoop.hbase.exceptions.UnknownProtocolException";
+  
+  final HBaseRpc failed_rpc;
+  
+  /**
+   * Package private ctor.
+   * @param msg The message of the exception, potentially with a stack trace.
+   * @param failed_rpc The RPC that caused this exception, if known, or null.
+   */
+  UnknownProtocolException(String msg, final HBaseRpc failed_rpc) {
+    super(msg);
+    this.failed_rpc = failed_rpc;
+  }
+
+  public HBaseRpc getFailedRpc() {
+    return failed_rpc;
+  }
+  
+  @Override
+  UnknownProtocolException make(final Object msg, final HBaseRpc rpc) {
+    if (msg == this || msg instanceof CallQueueTooBigException) {
+      final UnknownProtocolException e = (UnknownProtocolException) msg;
+      return new UnknownProtocolException(e.getMessage(), rpc);
+    }
+    return new UnknownProtocolException(msg.toString(), rpc);
+  }
+  private static final long serialVersionUID = -2266064834713807063L;
+}


### PR DESCRIPTION
UnknownProtocolException when called as per HBASE-20237. When caught
we'll set the flag to scan and try that call. Thanks @saintstack.