### PR TITLE
Add the option to track metadata surrounding NSRE's in a fixed size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,8 @@ asynchbase_SOURCES := \
 	src/NoSuchColumnFamilyException.java	\
 	src/NonRecoverableException.java	\
 	src/NotServingRegionException.java	\
+	src/NSREEvent.java	\
+	src/NSREMeta.java	\
 	src/PleaseThrottleException.java	\
 	src/PutRequest.java	\
 	src/QualifierFilter.java	\
@@ -182,6 +184,8 @@ unittest_SRC := \
 	test/TestHBaseRpc.java	\
 	test/TestMETALookup.java	\
 	test/TestMultiAction.java	\
+	test/TestNSREEvent.java	\
+	test/TestNSREMeta.java	\
 	test/TestNSREs.java	\
 	test/TestPutRequest.java	\
 	test/TestRegionClient.java	\
@@ -201,6 +205,7 @@ unittest_SRC := \
 
 test_LIBADD := \
 	$(asynchbase_LIBADD)	\
+	$(GUAVA_TEST)	\
 	$(LOG4J_OVER_SLF4J)	\
 	$(LOGBACK_CLASSIC)	\
 	$(LOGBACK_CORE)	\

--- a/pom.xml.in
+++ b/pom.xml.in
@@ -274,6 +274,13 @@
     <!-- test dependencies -->
 
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava-testlib</artifactId>
+      <version>@GUAVA_VERSION@</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-core</artifactId>
       <version>@HAMCREST_VERSION@</version>

--- a/src/Config.java
+++ b/src/Config.java
@@ -302,6 +302,7 @@ public class Config {
     default_map.put("hbase.region_client.check_channel_write_status", "false");
     default_map.put("hbase.region_client.inflight_limit", "0");
     default_map.put("hbase.region_client.pending_limit", "0");
+    default_map.put("hbase.nsre.event_queue_size", "128");
     default_map.put("hbase.nsre.low_watermark", "1000");
     default_map.put("hbase.nsre.high_watermark", "10000");
     default_map.put("hbase.timer.tick", "20");

--- a/src/HBaseRpc.java
+++ b/src/HBaseRpc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2012  The Async HBase Authors.  All rights reserved.
+ * Copyright (C) 2010-2018  The Async HBase Authors.  All rights reserved.
  * This file is part of Async HBase.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -180,12 +180,18 @@ public abstract class HBaseRpc {
     /** RPC method name to use with HBase 0.95+.  */
     static final byte[] MUTATE = { 'M', 'u', 't', 'a', 't', 'e' };
   }
+  
+  /** Whether or not the RPC should be traced. */
   private boolean trace_rpc;
 
+  /** @return Whether or not this is a traced RPC who's actions are logged
+   * to the trace log. */
   public boolean isTraceRPC() {
     return trace_rpc;
   }
 
+  /** @param trace_rpc Whether or not this is a traced RPC who's actions 
+   * are logged to the trace log. */
   public void setTraceRPC(boolean trace_rpc) {
     this.trace_rpc = trace_rpc;
   }

--- a/src/MultiAction.java
+++ b/src/MultiAction.java
@@ -128,6 +128,9 @@ final class MultiAction extends HBaseRpc implements HBaseRpc.IsEdit {
           " is missing the region or region name");
     }
     batch.add(rpc);
+    if (rpc.isTraceRPC()) {
+      setTraceRPC(true);
+    }
   }
 
   /** Returns the list of individual RPCs that make up this batch.  */

--- a/src/NSREEvent.java
+++ b/src/NSREEvent.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright (C) 2015  The Async HBase Authors.  All rights reserved.
+ * This file is part of Async HBase.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   - Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *   - Neither the name of the StumbleUpon nor the names of its contributors
+ *     may be used to endorse or promote products derived from this software
+ *     without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hbase.async;
+
+import java.util.Arrays;
+
+import com.google.common.base.Objects;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Description of an NSRE that HBase resolved.
+ * Given two NSRE metadata objects, this class determines how long the region
+ * was unavailable and provides a likely reason for the unavailability.
+ * @since 1.9
+ */
+public final class NSREEvent {
+  // For investigate/informative purposes.
+  private static final Logger LOG = LoggerFactory.getLogger(NSREEvent.class);
+
+  /** Probable reason for NSRE. */
+  public enum Reason {
+    COMPACTED_OR_OFFLINE,
+    MOVED,
+    SPLIT,
+    MOVED_AND_SPLIT, // likely due to region-server crash during split
+    UNKNOWN;
+  }
+
+  // The name of the affected region.
+  private final byte[] region_name;
+
+  // Why the NSRE probably happened.
+  private final Reason reason;
+
+  // When, in milliseconds, the NSRE was first detected.
+  private final long detection_time;
+
+  // When, in milliseconds, the NSRE's resolution was detected.
+  private final long resolution_time;
+  
+  // The original exception that triggered the NSRE
+  private final RecoverableException original_exception;
+
+  /**
+   * Create a new NSRE event instance.
+   * @param region_name The name of the region to which both instances of
+   * metadata apply.
+   * @param old_meta Data about the region immediately following the detection
+   * of the NSRE.
+   * @param new_meta Data about the region following the resolution of the
+   * NSRE.
+   */
+  public NSREEvent(final byte[] region_name, final NSREMeta old_meta,
+      final NSREMeta new_meta) {
+    if (null == region_name) {
+      throw new IllegalArgumentException("region name can't be null");
+    }
+    if (null == old_meta) {
+      throw new IllegalArgumentException("old metadata can't be null");
+    }
+    if (null == new_meta) {
+      throw new IllegalArgumentException("new metadata can't be null");
+    }
+    if (old_meta.getTime() > new_meta.getTime()) {
+      throw new IllegalArgumentException("timestamp for old metadata can't " +
+        "be greater than new-metadata timestamp");
+    }
+
+    this.region_name = region_name;
+    reason = why(old_meta, new_meta);
+    detection_time = old_meta.getTime();
+    resolution_time = new_meta.getTime();
+    original_exception = old_meta.getException();
+  }
+
+  /**
+   * Given information gathered upon NSRE detection and after NSRE resolution,
+   * attempt to determine why the exception occurred.
+   * @param old_meta The region state when the NSRE was detected.
+   * @param new_meta The new region state, now that the NSRE is resolved.
+   * @return probable reason for NSRE.
+   */
+  static Reason why(final NSREMeta old_meta, final NSREMeta new_meta) {
+    if (Arrays.equals(old_meta.getStartKey(), new_meta.getStartKey())) {
+      if (Arrays.equals(old_meta.getStopKey(), new_meta.getStopKey())) {
+        if (old_meta.getRemoteAddress().equals(new_meta.getRemoteAddress())) {
+          // Same start key, stop key, and server.
+          // Unfortunately, we can't easily disambiguate these two reasons.
+          return Reason.COMPACTED_OR_OFFLINE;
+        } else {
+          // Same start and stop keys, but different server.
+          return Reason.MOVED;
+        }
+      } else {
+        if (old_meta.getRemoteAddress().equals(new_meta.getRemoteAddress())) {
+          // Same server and start key, but different stop key.
+          return Reason.SPLIT;
+        } else {
+          // Same start key, but different server and stop key.
+          return Reason.MOVED_AND_SPLIT;
+        }
+      }
+    } else {
+      if (Arrays.equals(old_meta.getStopKey(), new_meta.getStopKey())) {
+        if (old_meta.getRemoteAddress().equals(new_meta.getRemoteAddress())) {
+          // Same server and stop key, but different start key.
+          return Reason.SPLIT;
+        } else {
+          // Same stop key, but different server and start key.
+          return Reason.MOVED_AND_SPLIT;
+        }
+      }
+    }
+
+    // Any other case should be impossible. In that case, we want to report an
+    // unknown reason. If you see any of these, something is very wrong.
+    {
+      final StringBuilder oss = new StringBuilder();
+      oss.append("Impossible unknown NSRE reason.\n")
+         .append("Old metadata: ").append(old_meta).append("\n")
+         .append("New metadata: ").append(new_meta).append("\n");
+      LOG.warn(oss.toString());
+    }
+    return Reason.UNKNOWN; 
+  }
+
+  /** @return the name of the region affected by NSRE. */
+  public String getRegionName() {
+    return Bytes.pretty(region_name);
+  }
+
+  /** @return likely reason for the NSRE. */
+  public Reason getReason() {
+    return reason;
+  }
+
+  /** @return when, in milliseconds, the NSRE was first detected. */
+  public long getDetectionTime() {
+    return detection_time;
+  }
+
+  /** @return when, in milliseconds, the NSRE's resolution was detected. */
+  public long getResolutionTime() {
+    return resolution_time;
+  }
+
+  /** @return how long, in milliseconds, HBase took to resolve the NSRE. */
+  public long getDuration() {
+    return getResolutionTime() - getDetectionTime();
+  }
+
+  /** @return the original exception associated with this event */
+  public String getOriginalException() {
+    return original_exception.getClass().getCanonicalName() + " " + original_exception.getMessage();
+  }
+  
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(Arrays.hashCode(region_name), reason,
+        detection_time, resolution_time);
+  }
+
+  @Override
+  public boolean equals(final Object other) {
+    if (null == other) {
+      return false;
+    }
+    if (this == other) {
+      return true;
+    }
+    if (getClass() != other.getClass()) {
+      return false;
+    }
+
+    final NSREEvent event = (NSREEvent)other;
+    return Arrays.equals(region_name, event.region_name) &&
+           Objects.equal(reason, event.reason) &&
+           Objects.equal(detection_time, event.detection_time) &&
+           Objects.equal(resolution_time, event.resolution_time);
+  }
+
+  @Override
+  public String toString() {
+    final StringBuilder buf = new StringBuilder();
+    buf.append("regionName=")
+       .append(Bytes.pretty(region_name))
+       .append(", reason=")
+       .append(reason)
+       .append(", detectionTime=")
+       .append(detection_time)
+       .append(", resolutionTime=")
+       .append(resolution_time)
+       .append(", duration=")
+       .append(getDuration())
+       .append(", originalException=")
+       .append(original_exception);
+    return buf.toString();
+  }
+}
+

--- a/src/NSREMeta.java
+++ b/src/NSREMeta.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C) 2015  The Async HBase Authors.  All rights reserved.
+ * This file is part of Async HBase.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   - Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *   - Neither the name of the StumbleUpon nor the names of its contributors
+ *     may be used to endorse or promote products derived from this software
+ *     without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hbase.async;
+
+import com.google.common.base.Objects;
+
+/**
+ * Utility class to store information about an NSRE thrown by HBase.
+ * @since 1.9
+ */
+final class NSREMeta {
+  // UNIX timestamp in msec when NSRE first detected.
+  private final long time;
+
+  // HBase region server that owned region.
+  private final String remote_address;
+
+  // HBase key at which region started.
+  private final byte[] start_key;
+
+  // The original region info object
+  private final RegionInfo original_region;
+  
+  // The original exception that triggered this NSRE. May be null if this is
+  // for a resolution.
+  private final RecoverableException original_exception; 
+
+  /**
+   * Create a new instance of the NSREMeta class.
+   * @param time The time, in milliseconds, when the NSRE was first detected.
+   * @param remote_address The hostname of the server on which the region lived.
+   * @param original_region The original region info associated with this NSRE
+   * @param original_exception The exception that triggered this NSRE
+   * @throws IllegalArgumentException if time negative
+   * @throws IllegalArgumentException if remote_address null or empty
+   * @throws IllegalArgumentException if start_key null
+   * @throws IllegalArgumentException if stop_key null
+   */
+  NSREMeta(final long time, final String remote_address, 
+      final RegionInfo original_region, 
+      final RecoverableException original_exception) {
+    // No one in this world can you trust. Not men, not women, not beasts...
+    // Not even other AsyncHBase programmers.
+    if (time < 0L) {
+      throw new IllegalArgumentException("timestamp can't be negative");
+    }
+    if (null == remote_address || remote_address.isEmpty()) {
+      throw new IllegalArgumentException("remote address must not be null or" +
+        " empty");
+    }
+    if (original_region == null) {
+      throw new IllegalArgumentException("Region info cannot be null");
+    }
+    if (original_region.name() == null) {
+      throw new IllegalArgumentException("Region name cannot be null");
+    }
+    this.time = time;
+    this.remote_address = remote_address;
+    this.original_region = original_region;
+    this.original_exception = original_exception;
+    
+    final String[] name_parts = new String(original_region.name()).split(",");
+    if (3 != name_parts.length) {
+      // Region name format is borked.
+      throw new IllegalArgumentException(
+          "Region name not in expected format: " + original_region);
+    }
+    // We got what we expected.
+    start_key = name_parts[1].getBytes();
+  }
+
+  /** @return the time in milliseconds at which the NSRE was first detected. */
+  long getTime() {
+    return time;
+  }
+
+  /** @return the hostname of the region server that owned the region. */
+  String getRemoteAddress() {
+    return remote_address;
+  }
+
+  /** @return the HBase key at which the region started. */
+  byte[] getStartKey() {
+    return start_key;
+  }
+
+  /** @return the HBase key at which the region ended. */
+  byte[] getStopKey() {
+    return original_region.stopKey();
+  }
+  
+  /** @return the original region info object */
+  RegionInfo getOriginalRegion() {
+    return original_region;
+  }
+  
+  /** @return the original exception. May be null. */
+  RecoverableException getException() {
+    return original_exception;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(time, remote_address,
+        original_region, original_exception);
+  }
+
+  @Override
+  public boolean equals(final Object other) {
+    if (null == other) {
+      return false;
+    }
+    if (this == other) {
+      return true;
+    }
+    if (getClass() != other.getClass()) {
+      return false;
+    }
+
+    final NSREMeta meta = (NSREMeta)other;
+    return Objects.equal(time, meta.time) &&
+           Objects.equal(remote_address, meta.remote_address) &&
+           Objects.equal(original_region, meta.original_region) &&
+           Objects.equal(original_exception, meta.original_exception);
+  }
+
+  @Override
+  public String toString() {
+    final StringBuilder buf = new StringBuilder();
+    buf.append("time=")
+       .append(time)
+       .append(", remoteAddress=")
+       .append(remote_address)
+       .append(", regionInfo=")
+       .append(original_region)
+       .append(", originalException=")
+       .append(original_exception);
+    return buf.toString();
+  }
+}
+

--- a/src/RegionClient.java
+++ b/src/RegionClient.java
@@ -914,7 +914,8 @@ public final class RegionClient extends ReplayingDecoder<VoidEnum> {
               // have come back successful, but only some parts of the batch
               // could have encountered an NSRE.
               hbase_client.handleNSRE(rpc, rpc.getRegion().name(),
-                                      (NotServingRegionException) r);
+                                      (NotServingRegionException) r,
+                                      chan.getRemoteAddress().toString());
             } else {
               retryEdit(rpc, (RecoverableException) r);
             }
@@ -1255,7 +1256,8 @@ public final class RegionClient extends ReplayingDecoder<VoidEnum> {
           new NotServingRegionException("Connection reset: "
                                         + exception.getMessage(), rpc);
         // Re-schedule the RPC by (ab)using the NSRE handling mechanism.
-        hbase_client.handleNSRE(rpc, region.name(), nsre);
+        hbase_client.handleNSRE(rpc, region.name(), nsre, 
+            chan.getRemoteAddress().toString());
       }
     }
   }
@@ -1593,7 +1595,8 @@ public final class RegionClient extends ReplayingDecoder<VoidEnum> {
       // if we don't know which region caused the NSRE (e.g. during multiPut)
       // we can't do anything about it.
       hbase_client.handleNSRE(rpc, rpc.getRegion().name(),
-                              (RecoverableException) decoded);
+                              (RecoverableException) decoded,
+                              chan.getRemoteAddress().toString());
       return null;
     }
 

--- a/test/BaseTestHBaseClient.java
+++ b/test/BaseTestHBaseClient.java
@@ -32,6 +32,7 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mock;
 
+import java.net.InetSocketAddress;
 import java.nio.charset.Charset;
 import java.util.AbstractMap;
 import java.util.ArrayList;
@@ -93,6 +94,7 @@ public class BaseTestHBaseClient {
   protected static final String ROOT_IP = "192.168.0.1";
   protected static final String META_IP = "192.168.0.2";
   protected static final String REGION_CLIENT_IP = "192.168.0.3";
+  protected static final String REMOTE_ADDRESS = "127.0.0.1/60020";
   protected static String MOCK_RS_CLIENT_NAME = "Mock RegionClient";
   protected static String MOCK_ROOT_CLIENT_NAME = "Mock RootClient";
   protected static String MOCK_META_CLIENT_NAME = "Mock MetaClient";
@@ -168,6 +170,9 @@ public class BaseTestHBaseClient {
     injectRegionInCache(meta, metaclient, META_IP + ":" + RS_PORT);
     injectRegionInCache(region, regionclient, REGION_CLIENT_IP + ":" + RS_PORT);
     
+    final InetSocketAddress remote = mock(InetSocketAddress.class);
+    when(remote.toString()).thenReturn(REMOTE_ADDRESS);
+    when(chan.getRemoteAddress()).thenReturn(remote);
     when(channel_factory.newChannel(any(ChannelPipeline.class)))
       .thenReturn(chan);
     when(chan.getConfig()).thenReturn(mock(SocketChannelConfig.class));

--- a/test/TestNSREEvent.java
+++ b/test/TestNSREEvent.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (C) 2015  The Async HBase Authors.  All rights reserved.
+ * This file is part of Async HBase.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   - Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *   - Neither the name of the StumbleUpon nor the names of its contributors
+ *     may be used to endorse or promote products derived from this software
+ *     without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hbase.async;
+
+import com.google.common.testing.EqualsTester;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestNSREEvent {
+  final static byte[] TABLE = new byte[] { 't' };
+  final static byte[] NAME_A = new byte[] { 't', ',', 0x42, ',', 
+    '1', '2', '3', '4', '5', '6', '7', '8', '9', '0'};
+  final static byte[] NAME_B = new byte[] { 't', ',', 0x43, ',', 
+    '1', '2', '3', '4', '5', '6', '7', '8', '9', '1'};
+  final static byte[] STOP_KEY_A = new byte[] { 0x44 };
+  final static byte[] STOP_KEY_B = new byte[] { 0x43 };
+  final static RecoverableException EX = new NotServingRegionException("Boo!", null);
+  final static RegionInfo REGION_A = new RegionInfo(TABLE, NAME_A, STOP_KEY_A);
+  final static RegionInfo REGION_B = new RegionInfo(TABLE, NAME_B, STOP_KEY_A);
+  final static RegionInfo REGION_C = new RegionInfo(TABLE, NAME_A, STOP_KEY_B);
+
+  private static final NSREMeta DUMMY_OLD_META = new NSREMeta(0L, "localhost",
+    REGION_A, EX);
+
+  private static final NSREMeta DUMMY_NEW_META = new NSREMeta(10L, "localhost",
+    REGION_B, null);
+
+  @Test(expected=IllegalArgumentException.class)
+  public void testConstructorNullRegionName() {
+    new NSREEvent(null, DUMMY_OLD_META, DUMMY_NEW_META);
+  }
+
+  @Test(expected=IllegalArgumentException.class)
+  public void testConstructorNullOldMetadata() {
+    new NSREEvent(NAME_B, null, DUMMY_NEW_META);
+  }
+
+  @Test(expected=IllegalArgumentException.class)
+  public void testConstructorNullNewMetadata() {
+    new NSREEvent(NAME_B, DUMMY_OLD_META, null);
+  }
+
+  @Test(expected=IllegalArgumentException.class)
+  public void testConstructorMalorderedTimestamps() {
+    final NSREMeta old_meta = new NSREMeta(400L, "whatever.yahoo.com",
+      REGION_A, EX);
+    final NSREMeta new_meta = new NSREMeta(0L, "whatever.yahoo.com",
+      REGION_B, EX);
+
+    new NSREEvent(NAME_B, old_meta, new_meta);
+  }
+
+  @Test
+  public void testConstructorIntegrated() {
+    final NSREMeta old_meta = new NSREMeta(1234L, "localhost", REGION_A, EX);
+    final NSREMeta new_meta = new NSREMeta(4567L, "localhost", REGION_B, EX);
+
+    final NSREEvent event = new NSREEvent(NAME_B, old_meta, new_meta);
+
+    assertEquals(NSREEvent.Reason.SPLIT, event.getReason());
+    assertEquals(1234L, event.getDetectionTime());
+    assertEquals(4567L, event.getResolutionTime());
+    assertEquals(4567L - 1234L, event.getDuration());
+  }
+
+  @Test
+  public void testWhySplit() {
+    // Same server and start key, but different stop key.
+    final NSREMeta old_meta = new NSREMeta(1234L, "localhost", REGION_A, EX);
+    NSREMeta new_meta = new NSREMeta(4567L, "localhost", REGION_B, EX);
+    assertEquals(NSREEvent.Reason.SPLIT, NSREEvent.why(old_meta, new_meta));
+
+    // Same server and stop key, but different start key.
+    new_meta = new NSREMeta(5678L, "localhost", REGION_C, EX);
+    assertEquals(NSREEvent.Reason.SPLIT, NSREEvent.why(old_meta, new_meta));
+  }
+
+  @Test
+  public void testWhyMoved() {
+    // Same start and stop keys, but different server.
+    final NSREMeta old_meta = new NSREMeta(1234L, "localhost", REGION_A, EX);
+    final NSREMeta new_meta = new NSREMeta(4567L, "elsewhere", REGION_A, EX);
+
+    assertEquals(NSREEvent.Reason.MOVED, NSREEvent.why(old_meta, new_meta));
+  }
+
+  @Test
+  public void testWhyCompactedOrOffline() {
+    // Same server, start key, and stop key.
+    final NSREMeta old_meta = new NSREMeta(1234L, "localhost", REGION_A, EX);
+    final NSREMeta new_meta = old_meta;
+
+    assertEquals(NSREEvent.Reason.COMPACTED_OR_OFFLINE,
+      NSREEvent.why(old_meta, new_meta));
+  }
+
+  /**
+   * We believe this case will most often occur when a region server crashes
+   * during a split.
+   */
+  @Test
+  public void testWhyMovedAndSplit() {
+    // Different server and start key, but different stop key.
+    final NSREMeta old_meta = new NSREMeta(17L, "here", REGION_A, EX);
+    NSREMeta new_meta = new NSREMeta(20L, "there", REGION_B, EX);
+    assertEquals(NSREEvent.Reason.MOVED_AND_SPLIT,
+      NSREEvent.why(old_meta, new_meta));
+
+    // Different server and stop key, but same start key.
+    new_meta = new NSREMeta(21L, "there", REGION_C, EX);
+    assertEquals(NSREEvent.Reason.MOVED_AND_SPLIT,
+      NSREEvent.why(old_meta, new_meta));
+  }
+
+  @Test
+  public void testWhyUnknown() {
+    // Same server, different start and stop keys.
+    // (Would be a different region -- makes no sense.)
+    final NSREMeta old_meta = new NSREMeta(17L, "here", REGION_A, EX);
+    NSREMeta new_meta = new NSREMeta(18L, "here", 
+        new RegionInfo(TABLE, new byte[] { 't', ',', 0x01, ',', '1' }, 
+            STOP_KEY_B), EX);
+    assertEquals(NSREEvent.Reason.UNKNOWN, NSREEvent.why(old_meta, new_meta));
+
+    // Different server, start key, and stop key.
+    // (Different region on different server -- even less meaningful.)
+    new_meta = new NSREMeta(19L, "there",  
+        new RegionInfo(TABLE, new byte[] { 't', ',', 0x01, ',', '1' }, 
+        STOP_KEY_B), EX);
+    assertEquals(NSREEvent.Reason.UNKNOWN, NSREEvent.why(old_meta, new_meta));
+  }
+
+  @Test
+  public void testEqualsAndHashCode() {
+    final NSREMeta a = new NSREMeta(50L, new String("omg"), REGION_A, EX);
+    final NSREMeta b = new NSREMeta(75L, "o" + "m" + "g", REGION_A, EX);
+    final NSREMeta c = new NSREMeta(60L, "never", REGION_B, EX);
+    final NSREMeta d = new NSREMeta(112L, "n" + "ev" + "er", REGION_B, EX);
+
+    final NSREEvent one = new NSREEvent(new byte[] {'x'}, a, b);
+    final NSREEvent two = new NSREEvent(new byte[] {'x'}, a, b);
+    final NSREEvent three = new NSREEvent(new byte[] {'z'}, c, d);
+    final NSREEvent four = new NSREEvent(new byte[] {'z'}, c, d);
+    new EqualsTester().
+      addEqualityGroup(one, two).
+      addEqualityGroup(three, four).
+      testEquals();
+  }
+}
+

--- a/test/TestNSREMeta.java
+++ b/test/TestNSREMeta.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2015  The Async HBase Authors.  All rights reserved.
+ * This file is part of Async HBase.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   - Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *   - Neither the name of the StumbleUpon nor the names of its contributors
+ *     may be used to endorse or promote products derived from this software
+ *     without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hbase.async;
+
+import java.util.Arrays;
+
+import com.google.common.testing.EqualsTester;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class TestNSREMeta {
+  final static byte[] TABLE = new byte[] { 't' };
+  final static byte[] NAME = new byte[] { 't', ',', 0x42, ',', 
+    '1', '2', '3', '4', '5', '6', '7', '8', '9', '0'};
+  final static byte[] STOP_KEY = new byte[] { 0x43 };
+  final static RecoverableException EX = new NotServingRegionException("Boo!", null);
+  final static RegionInfo REGION = new RegionInfo(TABLE, NAME, STOP_KEY);
+  
+  @Test(expected=IllegalArgumentException.class)
+  public void testConstructorNegativeTimestamp() {
+    new NSREMeta(-2L, "klaatu", REGION, EX);
+  }
+
+  @Test(expected=IllegalArgumentException.class)
+  public void testConstructorNullRemoteAddress() {
+    new NSREMeta(342L, null, REGION, EX);
+  }
+
+  @Test(expected=IllegalArgumentException.class)
+  public void testConstructorEmptyRemoteAddress() {
+    new NSREMeta(12345L, "", REGION, EX);
+  }
+
+  @Test(expected=IllegalArgumentException.class)
+  public void testConstructorNullRegion() {
+    new NSREMeta(8493L, "barada", null, EX);
+  }
+  
+  @Test(expected=IllegalArgumentException.class)
+  public void testConstructorNullName() {
+    new NSREMeta(8493L, "barada", new RegionInfo(TABLE, null, STOP_KEY), EX);
+  }
+
+  @Test
+  public void testConstructor() {
+    final long timestamp = 584L;
+    final String address = "localhost";
+
+    final NSREMeta meta = new NSREMeta(timestamp, address, REGION, EX);
+
+    assertEquals(timestamp, meta.getTime());
+    assertEquals(address, meta.getRemoteAddress());
+    assertTrue(Arrays.equals(new byte[] { 0x42 }, meta.getStartKey()));
+    assertTrue(Arrays.equals(STOP_KEY, meta.getStopKey()));
+  }
+
+  @Test
+  public void testToStringIntegrated() {
+    final String string = new NSREMeta(1234567890L, "127.0.0.1:5011", REGION, EX)
+      .toString();
+    assertTrue(string.contains("time=1234567890"));
+    assertTrue(string.contains("remoteAddress=127.0.0.1:5011"));
+    assertTrue(string.contains("region_name=\"t,B,1234567890\""));
+    assertTrue(string.contains("stop_key=\"C\""));
+    assertTrue(string.contains(
+        "originalException=org.hbase.async.NotServingRegionException: Boo!"));
+  }
+
+  @Test
+  public void testEqualsAndHashCode() {
+    final NSREMeta one = new NSREMeta(50L, new String("omg"),
+      new RegionInfo(TABLE, NAME, STOP_KEY), EX);
+    final NSREMeta two = new NSREMeta(50L, "o" + "m" + "g",
+        new RegionInfo(TABLE, NAME, STOP_KEY), EX);
+
+    new EqualsTester().
+      addEqualityGroup(one, two).
+      testEquals();
+  }
+}
+

--- a/test/TestRegionClient.java
+++ b/test/TestRegionClient.java
@@ -417,7 +417,7 @@ public class TestRegionClient extends BaseTestRegionClient {
     PowerMockito.when(rpc, "getRegion").thenReturn(region);
     PowerMockito.when(region, "name").thenReturn(Bytes.fromInt(1337));
     PowerMockito.doNothing().when(hbase_client, "handleNSRE", Mockito.any(), 
-        Mockito.any(), Mockito.any());
+        Mockito.any(), Mockito.any(), Mockito.any());
     PowerMockito.when(rclient, "deserialize", buf, rpc).thenReturn(blowzup);
       
     PowerMockito.when(rclient, "decode", (ChannelHandlerContext)any(), 

--- a/test/TestRegionClientDecode.java
+++ b/test/TestRegionClientDecode.java
@@ -35,6 +35,7 @@ import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -86,7 +87,7 @@ public class TestRegionClientDecode extends BaseTestRegionClient {
   private static final long TIMESTAMP = 1356998400000L;
   
   // NOTE: the TYPE of ChannelBuffer is important! ReplayingDecoderBuffer isn't
-  // backed by an array and we have methods that attemp to see if they can
+  // backed by an array and we have methods that attempt to see if they can
   // perform zero copy operations.
   
   @Before
@@ -355,7 +356,7 @@ public class TestRegionClientDecode extends BaseTestRegionClient {
 
     assertEquals(0, rpcs_inflight.size());
     verify(hbase_client, times(1)).handleNSRE(any(HBaseRpc.class),
-        any(byte[].class), any(RecoverableException.class));
+        any(byte[].class), any(RecoverableException.class), anyString());
     assertEquals(1, timer.tasks.size());
     assertEquals(60000, (long)timer.tasks.get(0).getValue());
     verify(timer.timeouts.get(0), never()).cancel();
@@ -399,7 +400,7 @@ public class TestRegionClientDecode extends BaseTestRegionClient {
 
     assertEquals(0, rpcs_inflight.size());
     verify(hbase_client, times(1)).handleNSRE(any(HBaseRpc.class), 
-        any(byte[].class), any(RecoverableException.class));
+        any(byte[].class), any(RecoverableException.class), anyString());
     assertEquals(1, timer.tasks.size());
     assertEquals(60000, (long)timer.tasks.get(0).getValue());
     verify(timer.timeouts.get(0), never()).cancel();
@@ -418,7 +419,7 @@ public class TestRegionClientDecode extends BaseTestRegionClient {
 
     assertEquals(0, rpcs_inflight.size());
     verify(hbase_client, never()).handleNSRE(any(HBaseRpc.class), 
-        any(byte[].class), any(RecoverableException.class));
+        any(byte[].class), any(RecoverableException.class), anyString());
     assertEquals(1, timer.tasks.size());
     assertEquals(60000, (long)timer.tasks.get(0).getValue());
     verify(timer.timeouts.get(0), times(1)).cancel();
@@ -437,7 +438,7 @@ public class TestRegionClientDecode extends BaseTestRegionClient {
 
     assertEquals(0, rpcs_inflight.size());
     verify(hbase_client, never()).handleNSRE(any(HBaseRpc.class), 
-        any(byte[].class), any(RecoverableException.class));
+        any(byte[].class), any(RecoverableException.class), anyString());
     assertEquals(1, timer.tasks.size());
     assertEquals(60000, (long)timer.tasks.get(0).getValue());
     verify(timer.timeouts.get(0), times(1)).cancel();
@@ -456,7 +457,7 @@ public class TestRegionClientDecode extends BaseTestRegionClient {
 
     assertEquals(0, rpcs_inflight.size());
     verify(hbase_client, never()).handleNSRE(any(HBaseRpc.class), 
-        any(byte[].class), any(RecoverableException.class));
+        any(byte[].class), any(RecoverableException.class), anyString());
     assertEquals(1, timer.tasks.size());
     assertEquals(60000, (long)timer.tasks.get(0).getValue());
     verify(timer.timeouts.get(0), times(1)).cancel();

--- a/third_party/guava/include.mk
+++ b/third_party/guava/include.mk
@@ -27,7 +27,13 @@ GUAVA_VERSION := 18.0
 GUAVA := third_party/guava/guava-$(GUAVA_VERSION).jar
 GUAVA_BASE_URL := http://central.maven.org/maven2/com/google/guava/guava/$(GUAVA_VERSION)
 
+GUAVA_TEST := third_party/guava/guava-testlib-$(GUAVA_VERSION).jar
+GUAVA_TEST_BASE_URL := http://central.maven.org/maven2/com/google/guava/guava-testlib/$(GUAVA_VERSION)
+
 $(GUAVA): $(GUAVA).md5
 	set dummy "$(GUAVA_BASE_URL)" "$(GUAVA)"; shift; $(FETCH_DEPENDENCY)
+	
+$(GUAVA_TEST): $(GUAVA_TEST).md5
+	set dummy "$(GUAVA_TESTBASE_URL)" "$(GUAVA_TEST)"; shift; $(FETCH_DEPENDENCY)
 
-THIRD_PARTY += $(GUAVA)
+THIRD_PARTY += $(GUAVA) $(GUAVA_TEST)


### PR DESCRIPTION
queue that can be emitted for debugging purposes.