### PR TITLE
expose `hbase.ipc.client.connection.idle_{read|write}_timeout`

### DIFF
--- a/src/ClientStats.java
+++ b/src/ClientStats.java
@@ -121,7 +121,10 @@ public final class ClientStats {
 
   /**
    * Returns the number of connections to region servers that were closed
-   * due to being idle past the "hbase.hbase.ipc.client.connection.idle_timeout"
+   * due to being idle past one of
+   * "hbase.hbase.ipc.client.connection.idle_timeout",
+   * "hbase.ipc.client.connection.idle_read_timeout", or
+   * "hbase.ipc.client.connection.idle_write_timeout"
    * value. 
    * @return The number of idle connections over time
    * @since 1.7

--- a/src/Config.java
+++ b/src/Config.java
@@ -309,7 +309,9 @@ public class Config {
     default_map.put("hbase.security.auth.enable", "false");
     default_map.put("hbase.zookeeper.getroot.retry_delay", "1000");
     default_map.put("hbase.hbase.ipc.client.connection.idle_timeout", "300");
-    
+    default_map.put("hbase.ipc.client.connection.idle_read_timeout", "0");
+    default_map.put("hbase.ipc.client.connection.idle_write_timeout", "0");
+
     /**
      * How many different counters do we want to keep in memory for buffering.
      * Each entry requires storing the table name, row key, family name and


### PR DESCRIPTION
**Problem**: `RegionClient` doesn't disconnect in the case of a half-open TCP connection, which we see when a Region Server goes offline abruptly without gracefully closing its TCP connections. Even with `hbase.hbase.ipc.client.connection.idle_timeout` being set, an application with a heavy request load will keep talking to the channel and `IdleState.ALL_IDLE` will never be triggered, meaning the `RegionClient` will never be closed even after HBase has areadly recovered and reassigned the regions to other Region Servers. 

One way to cause `IdleStat.ALL_IDLE` to trigger is by setting `hbase.region_client.inflight_limit`, which once reached will prevent further writes to the channel, thereby triggering `IdleState.ALL_IDLE`; however, this is isn't good enough as different clients/applications have different write loads, making it difficult to figure out reasonable inflight limits to apply everywhere.

**Solution**: set the new `hbase.ipc.client.connection.read_timeout`, allowing us to detect when a Region Server has stopped responding without requiring us to stop writing to it as well. We now close the channel on any `IdleState`.

We don't really need `hbase.ipc.client.connection.write_timeout`, but since we're exposing `readerIdleTimeSeconds` and `allIdleTimeSeconds`, might as well expose `writerIdleTimeSeconds` for completeness.