### PR TITLE
change UnknownScannerException to NonRecoverableException

### DIFF
--- a/src/RegionClient.java
+++ b/src/RegionClient.java
@@ -1547,6 +1547,7 @@ final class RegionClient extends ReplayingDecoder<VoidEnum> {
       final class RetryTimer implements TimerTask {
         public void run(final Timeout timeout) {
           if (isAlive()) {
+            rpc.attempt++;
             sendRpc(rpc);
           } else {
             if (rpc instanceof MultiAction) {

--- a/src/UnknownScannerException.java
+++ b/src/UnknownScannerException.java
@@ -29,7 +29,7 @@ package org.hbase.async;
 /**
  * Exception thrown when we try to use an invalid or expired scanner ID.
  */
-public final class UnknownScannerException extends RecoverableException
+public final class UnknownScannerException extends NonRecoverableException
 implements HasFailedRpcException {
 
   static final String REMOTE_CLASS =


### PR DESCRIPTION
PR of issue : https://github.com/OpenTSDB/asynchbase/issues/198

1. We change the UnknownScannerException to NonRecoverableException.
2. When decode a RecoverableException rpc, increment rpc attempt count before resend rpc although channel keep alive from remote server.