### PR TITLE
Add capability to configure DNS lookup latency WARN threshold

### DIFF
--- a/src/Config.java
+++ b/src/Config.java
@@ -314,7 +314,7 @@ public class Config {
     default_map.put("hbase.ipc.client.connection.idle_read_timeout", "0");
     default_map.put("hbase.ipc.client.connection.idle_write_timeout", "0");
 
-    /**
+    /*
      * How many different counters do we want to keep in memory for buffering.
      * Each entry requires storing the table name, row key, family name and
      * column qualifier, plus 4 small objects.
@@ -327,6 +327,11 @@ public class Config {
      * to expect they'd tune this value to cater to their unusual requirements.
      */
     default_map.put("hbase.increments.buffer_size", "65535");
+
+    /*
+     * HBaseClient will logs WARN if DNS-lookup takes longer than this threshold.
+     */
+    default_map.put("hbase.dns.latency_warn_threshold_nanos", "3000000");
     
     /* --- HBase configs (same names as their HTable counter parts --- 
      * Note that the defaults may differ though */
@@ -335,7 +340,8 @@ public class Config {
     default_map.put("hbase.zookeeper.znode.parent", "/hbase");
     default_map.put("hbase.zookeeper.session.timeout", "5000");
     default_map.put("hbase.client.retries.number", "10");
-    /** Note that HBase's client defaults to 60 seconds. We default to 0 for
+    /*
+     * Note that HBase's client defaults to 60 seconds. We default to 0 for
      * AsyncHBase backwards compatibility. This may change in the future.
      */
     default_map.put("hbase.rpc.timeout", "0");

--- a/src/HBaseClient.java
+++ b/src/HBaseClient.java
@@ -466,6 +466,9 @@ public final class HBaseClient {
   
   /** Whether or not increments are batched. */
   private boolean increment_buffer_durable = false;
+
+  /** WARN threshold of DNS lookup latency */
+  private final long dns_latency_warn_threshold_nanos;
   
   // ------------------------ //
   // Client usage statistics. //
@@ -596,6 +599,7 @@ public final class HBaseClient {
     nsre_low_watermark = config.getInt("hbase.nsre.low_watermark");
     nsre_high_watermark = config.getInt("hbase.nsre.high_watermark");
     jitter_percent = config.getInt("hbase.rpcs.jitter");
+    dns_latency_warn_threshold_nanos = config.getLong("hbase.dns.latency_warn_threshold_nanos");
     if (config.properties.containsKey("hbase.increments.durable")) {
       increment_buffer_durable = config.getBoolean("hbase.increments.durable");
     }
@@ -675,6 +679,7 @@ public final class HBaseClient {
     nsre_low_watermark = config.getInt("hbase.nsre.low_watermark");
     nsre_high_watermark = config.getInt("hbase.nsre.high_watermark");
     jitter_percent = config.getInt("hbase.rpcs.jitter");
+    dns_latency_warn_threshold_nanos = config.getLong("hbase.dns.latency_warn_threshold_nanos");
     
     if (config.properties.containsKey("hbase.increments.durable")) {
       increment_buffer_durable = config.getBoolean("hbase.increments.durable");
@@ -2700,7 +2705,7 @@ public final class HBaseClient {
                   + " doesn't contain `:' to separate the `host:port'"
                   + Bytes.pretty(hostport), kv);
         }
-        host = getIP(new String(hostport, 0, colon));
+        host = getIP(new String(hostport, 0, colon), dns_latency_warn_threshold_nanos);
         try {
           port = parsePortNumber(new String(hostport, colon + 1,
                   hostport.length - colon - 1));
@@ -3320,7 +3325,7 @@ public final class HBaseClient {
             + " doesn't contain `:' to separate the `host:port'"
             + Bytes.pretty(hostport), kv);
         }
-        host = getIP(new String(hostport, 0, colon));
+        host = getIP(new String(hostport, 0, colon), dns_latency_warn_threshold_nanos);
         try {
           port = parsePortNumber(new String(hostport, colon + 1,
                                             hostport.length - colon - 1));
@@ -4303,7 +4308,7 @@ public final class HBaseClient {
       LOG.error("WTF?  Should never happen!  No `:' found in " + hostport);
       return null;
     }
-    final String host = getIP(hostport.substring(0, lastColon));
+    final String host = getIP(hostport.substring(0, lastColon), dns_latency_warn_threshold_nanos);
     int port;
     try {
       port = parsePortNumber(hostport.substring(lastColon + 1,
@@ -4795,7 +4800,7 @@ public final class HBaseClient {
         }
         final int port = parsePortNumber(new String(data, firstsep + 1,
                                                     portend - firstsep - 1));
-        final String ip = getIP(host);
+        final String ip = getIP(host, dns_latency_warn_threshold_nanos);
         if (ip == null) {
           LOG.error("Couldn't resolve the IP of the -ROOT- region from "
                     + host + " in \"" + Bytes.pretty(data) + '"');
@@ -4840,7 +4845,7 @@ public final class HBaseClient {
           final ZooKeeperPB.MetaRegionServer meta =
             ZooKeeperPB.MetaRegionServer.newBuilder()
             .mergeFrom(data, offset, data.length - offset).build();
-          ip = getIP(meta.getServer().getHostName());
+          ip = getIP(meta.getServer().getHostName(), dns_latency_warn_threshold_nanos);
           port = meta.getServer().getPort();
         } catch (InvalidProtocolBufferException e) {
           LOG.error("Failed to parse the protobuf in " + Bytes.pretty(data), e);
@@ -4898,7 +4903,7 @@ public final class HBaseClient {
    * @return The IP address associated with the given hostname,
    * or {@code null} if the address couldn't be resolved.
    */
-  private static String getIP(final String host) {
+  private static String getIP(final String host, final long latencyWarnThresholdNanos) {
     final long start = System.nanoTime();
     try {
       boolean preferV6 = Boolean.valueOf(
@@ -4928,7 +4933,7 @@ public final class HBaseClient {
       if (latency > 500000/*ns*/ && LOG.isDebugEnabled()) {
         LOG.debug("Resolved IP of `" + host + "' to "
                   + ip + " in " + latency + "ns");
-      } else if (latency >= 3000000/*ns*/) {
+      } else if (latency >= latencyWarnThresholdNanos) {
         LOG.warn("Slow DNS lookup!  Resolved IP of `" + host + "' to "
                  + ip + " in " + latency + "ns");
       }


### PR DESCRIPTION
Hardcoded threshold (3000000) is too short for my environment.
(But I don't want to ignore WARN completely)
To solve this, I added a capability to configure WARN threshold,