### PR TITLE
Allow blocking root requests if the semaphore has been exhausted.

### DIFF
--- a/src/Config.java
+++ b/src/Config.java
@@ -348,6 +348,7 @@ public class Config {
     default_map.put("hbase.ipc.client.socket.timeout.connect", "5000");
     default_map.put("hbase.ipc.client.tcpnodelay", "true");
     default_map.put("hbase.ipc.client.tcpkeepalive", "true");
+    default_map.put("hbase.ipc.client.exceptions.generic_throttles", "false");
     
     // default rate limiter values
     // Maximum write rate restriction per second, there will not be any 

--- a/src/HBaseRpc.java
+++ b/src/HBaseRpc.java
@@ -442,6 +442,9 @@ public abstract class HBaseRpc implements TimerTask {
   /** Whether or not this RPC has timed out already */
   private boolean has_timedout;
   
+  /** When this RPC was instantiated in ms, used to track it's age */
+  private final long created;
+  
   /**
    * If true, this RPC should fail-fast as soon as we know we have a problem.
    */
@@ -519,6 +522,7 @@ public abstract class HBaseRpc implements TimerTask {
   HBaseRpc() {
     table = null;
     key = null;
+    created = System.currentTimeMillis();
   }
 
   /**
@@ -531,6 +535,7 @@ public abstract class HBaseRpc implements TimerTask {
     KeyValue.checkKey(key);
     this.table = table;
     this.key = key;
+    created = System.currentTimeMillis();
   }
 
   /**
@@ -918,6 +923,11 @@ public abstract class HBaseRpc implements TimerTask {
     return attempt < 4
         ? 200 * (attempt + 2)     // 400, 600, 800, 1000
         : 1000 + (1 << attempt);  // 1016, 1032, 1064, 1128, 1256, 1512, ..
+  }
+  
+  /** @return The age of this RPC in ms. */
+  long age() {
+    return System.currentTimeMillis() - created;
   }
   
   /**

--- a/src/MultiAction.java
+++ b/src/MultiAction.java
@@ -723,6 +723,16 @@ class MultiAction extends HBaseRpc implements HBaseRpc.IsEdit {
   }
 
   /**
+   * Updates the attempts on all nested RPCs.
+   */
+  void incrementAttempts() {
+    attempt++;
+    for (int i = 0; i < batch.size(); i++) {
+      batch.get(i).attempt++;
+    }
+  }
+  
+  /**
    * De-serializes the response to a {@link MultiAction} RPC.
    * See HBase's {@code MultiResponse}.
    * Only used with HBase 0.94 and earlier.

--- a/test/BaseTestRegionClient.java
+++ b/test/BaseTestRegionClient.java
@@ -114,7 +114,7 @@ public class BaseTestRegionClient {
       }
     }).when(hbase_client, "newClient", anyString(), anyInt());
     
-    region_client = PowerMockito.spy(new RegionClient(hbase_client, null));
+    region_client = PowerMockito.spy(new RegionClient(hbase_client, null, "localhost"));
     Whitebox.setInternalState(region_client, "chan", chan);
     Whitebox.setInternalState(region_client, "server_version", 
         RegionClient.SERVER_VERSION_095_OR_ABOVE);

--- a/test/TestHBaseClientLocateRegion.java
+++ b/test/TestHBaseClientLocateRegion.java
@@ -767,7 +767,7 @@ public class TestHBaseClientLocateRegion extends BaseTestHBaseClient {
   private void assertCounters(final int root_lookups, 
       final int meta_lookups_with_permit, final int meta_lookups_wo_permit) {
     assertEquals(root_lookups, 
-        ((Counter)Whitebox.getInternalState(client, "root_lookups")).get());
+        ((Counter)Whitebox.getInternalState(client, "root_lookups_with_permit")).get());
     assertEquals(meta_lookups_with_permit, 
         ((Counter)Whitebox.getInternalState(client, 
             "meta_lookups_with_permit")).get());

--- a/test/TestMultiActionAppend.java
+++ b/test/TestMultiActionAppend.java
@@ -111,7 +111,7 @@ public class TestMultiActionAppend {
     client = mock(HBaseClient.class);
     Config config = new Config();
     when(client.getConfig()).thenReturn(config);
-    rc = new RegionClient(client, null);
+    rc = new RegionClient(client, null, "localhost");
     channel = mock(Channel.class);
     when(channel.getLocalAddress()).thenReturn(mock(SocketAddress.class));
     Whitebox.setInternalState(rc, "chan", channel);

--- a/test/TestRegionClient.java
+++ b/test/TestRegionClient.java
@@ -77,24 +77,24 @@ public class TestRegionClient extends BaseTestRegionClient {
 
   @Test
   public void ctor() throws Exception {
-    assertNotNull(new RegionClient(hbase_client, null));
+    assertNotNull(new RegionClient(hbase_client, null, "localhost"));
   }
   
   @Test (expected = NullPointerException.class)
   public void ctorNullClient() throws Exception {
-    new RegionClient(null, null);
+    new RegionClient(null, null, "localhost");
   }
 
   @Test
   public void getClosestRowBefore() throws Exception {
-    final RegionClient rclient = new RegionClient(hbase_client, null);
+    final RegionClient rclient = new RegionClient(hbase_client, null, "localhost");
     rclient.getClosestRowBefore(region, TABLE, KEY, FAMILY);
     verifyPrivate(rclient).invoke("sendRpc", rpc);
   }
   
   @Test
   public void getRemoteAddressChanNotSet() throws Exception {
-    RegionClient rclient = new RegionClient(hbase_client, null);
+    RegionClient rclient = new RegionClient(hbase_client, null, "localhost");
     
     assertNull(Whitebox.getInternalState(rclient, "chan"));
     assertNull(rclient.getRemoteAddress());
@@ -117,7 +117,8 @@ public class TestRegionClient extends BaseTestRegionClient {
   public void exceptionCaught() throws Exception {
     PowerMockito.mockStatic(Channels.class);
     when(chan.isOpen()).thenReturn(true);
-    final RegionClient rclient = PowerMockito.spy(new RegionClient(hbase_client, null));
+    final RegionClient rclient = PowerMockito.spy(new RegionClient(
+        hbase_client, null, "localhost"));
     PowerMockito.field(RegionClient.class, "chan").set(rclient, chan);
     final ExceptionEvent event = new DefaultExceptionEvent(chan, 
         new RuntimeException("Boo!"));
@@ -132,7 +133,8 @@ public class TestRegionClient extends BaseTestRegionClient {
   @Test
   public void exceptionCaughtChNotOpen() throws Exception {
     PowerMockito.mockStatic(Channels.class);
-    final RegionClient rclient = PowerMockito.spy(new RegionClient(hbase_client, null));
+    final RegionClient rclient = PowerMockito.spy(new RegionClient(
+        hbase_client, null, "localhost"));
     PowerMockito.field(RegionClient.class, "chan").set(rclient, chan);
     final ExceptionEvent event = new DefaultExceptionEvent(chan, 
         new RuntimeException("Boo!"));
@@ -146,13 +148,13 @@ public class TestRegionClient extends BaseTestRegionClient {
   
   @Test (expected = NullPointerException.class)
   public void exceptionCaughtNullEvent() throws Exception {
-    final RegionClient rclient = new RegionClient(hbase_client, null);
+    final RegionClient rclient = new RegionClient(hbase_client, null, "localhost");
     rclient.exceptionCaught(null, null);
   }
   
   @Test (expected = NullPointerException.class)
   public void exceptionCaughtNullChannel() throws Exception {
-    final RegionClient rclient = new RegionClient(hbase_client, null);
+    final RegionClient rclient = new RegionClient(hbase_client, null, "localhost");
     final ExceptionEvent event = new DefaultExceptionEvent(null, 
         new RuntimeException("Boo!"));
     rclient.exceptionCaught(null, event);
@@ -160,7 +162,7 @@ public class TestRegionClient extends BaseTestRegionClient {
   
   @Test (expected = NullPointerException.class)
   public void exceptionCaughtNullException() throws Exception {
-    final RegionClient rclient = new RegionClient(hbase_client, null);
+    final RegionClient rclient = new RegionClient(hbase_client, null, "localhost");
     final ExceptionEvent event = new DefaultExceptionEvent(chan, null);
     rclient.exceptionCaught(null, event);
   }
@@ -172,7 +174,8 @@ public class TestRegionClient extends BaseTestRegionClient {
     // honey badger don't care; apparently we can call this with any old channel.
     final Channel ch = mock(Channel.class, Mockito.RETURNS_DEEP_STUBS);
     when(ch.isOpen()).thenReturn(true);
-    final RegionClient rclient = PowerMockito.spy(new RegionClient(hbase_client, null));
+    final RegionClient rclient = PowerMockito.spy(new RegionClient(
+        hbase_client, null, "localhost"));
     PowerMockito.field(RegionClient.class, "chan").set(rclient, chan);
     final ExceptionEvent event = new DefaultExceptionEvent(ch, 
         new RuntimeException("Boo!"));
@@ -189,7 +192,8 @@ public class TestRegionClient extends BaseTestRegionClient {
     PowerMockito.mockStatic(Channels.class);
     // honey badger don't care; apparently we can call this with any old channel.
     final Channel ch = mock(Channel.class, Mockito.RETURNS_DEEP_STUBS);
-    final RegionClient rclient = PowerMockito.spy(new RegionClient(hbase_client, null));
+    final RegionClient rclient = PowerMockito.spy(new RegionClient(
+        hbase_client, null, "localhost"));
     PowerMockito.field(RegionClient.class, "chan").set(rclient, chan);
     final ExceptionEvent event = new DefaultExceptionEvent(ch, 
         new RuntimeException("Boo!"));
@@ -204,7 +208,8 @@ public class TestRegionClient extends BaseTestRegionClient {
   @SuppressWarnings("rawtypes")
   @Test
   public void channelDisconnected() throws Exception {
-    RegionClient rclient = PowerMockito.spy(new RegionClient(hbase_client, null));
+    RegionClient rclient = PowerMockito.spy(new RegionClient(
+        hbase_client, null, "localhost"));
     PowerMockito.field(RegionClient.class, "chan").set(rclient, chan);
     
     when(cse.getChannel()).thenReturn(chan);
@@ -222,7 +227,7 @@ public class TestRegionClient extends BaseTestRegionClient {
   
   @Test
   public void channelClosed() throws Exception {
-    RegionClient rclient = new RegionClient(hbase_client, null);
+    RegionClient rclient = new RegionClient(hbase_client, null, "localhost");
     assertNotNull(rclient);
     rclient.becomeReady(chan, SERVER_VERSION_UNKNOWN);
     
@@ -454,13 +459,13 @@ public class TestRegionClient extends BaseTestRegionClient {
   
   @Test (expected=InvalidResponseException.class)
   public void badResponse() throws Exception {
-    RegionClient rclient = new RegionClient(hbase_client, null);
+    RegionClient rclient = new RegionClient(hbase_client, null, "localhost");
     Whitebox.invokeMethod(rclient, "badResponse", "ZOMG ERRMSG"); 
   }
   
   @Test
   public void commonHeader() throws Exception {
-    RegionClient rclient = new RegionClient(hbase_client, null);
+    RegionClient rclient = new RegionClient(hbase_client, null, "localhost");
     final byte[] buf = new byte[42];
     
     ChannelBuffer commonHeader = 

--- a/test/TestRegionClientDecode.java
+++ b/test/TestRegionClientDecode.java
@@ -2118,7 +2118,7 @@ public class TestRegionClientDecode extends BaseTestRegionClient {
    * tests
    */
   private void resetMockClient() throws Exception {
-    region_client = new RegionClient(hbase_client, null);
+    region_client = new RegionClient(hbase_client, null, "localhost");
     Whitebox.setInternalState(region_client, "chan", chan);
     Whitebox.setInternalState(region_client, "server_version", 
         RegionClient.SERVER_VERSION_095_OR_ABOVE);


### PR DESCRIPTION
Add a flag, hbase.ipc.client.exceptions.generic_throttles, that will return
generic exceptions that are initialized once to avoid stack tracing when we
don't really care to cary the RPCs along.
Fix a loop with local retries where we never increment the attempts.
Force multiaction RPCs to split apart when handling NSREs.