### PR TITLE
Fix the rate limiter so we only increment the success if there wasn't

### DIFF
--- a/src/RegionClient.java
+++ b/src/RegionClient.java
@@ -1971,7 +1971,9 @@ public final class RegionClient extends ReplayingDecoder<VoidEnum> {
               + " Response: " + decoded);
         }
         
-        rate_limiter.ping(WriteRateLimiter.SIGNAL.SUCCESS);
+        if (!(decoded instanceof Exception)) {
+          rate_limiter.ping(WriteRateLimiter.SIGNAL.SUCCESS);
+        }
         if (rpc.isProbe()) {
           ++probes_succeded;
         }


### PR DESCRIPTION
an exception for the RPCs.